### PR TITLE
Add more models and utilities to the scripts

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,3 +1,3 @@
-from .parse import Token, Tokens, OsVersion, Translation
+from .parse import Token, Tokens, OsVersion, OsVersions, Translation
 
-__all__ = ["Token", "Tokens", "OsVersion", "Translation"]
+__all__ = ["Token", "Tokens", "OsVersion", "OsVersions", "Translation"]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,3 +1,4 @@
 from .parse import Token, Tokens, OsVersion, OsVersions, Translation
+from .trie import TokenTrie
 
-__all__ = ["Token", "Tokens", "OsVersion", "OsVersions", "Translation"]
+__all__ = ["Token", "Tokens", "OsVersion", "OsVersions", "Translation", "TokenTrie"]

--- a/scripts/parse.py
+++ b/scripts/parse.py
@@ -1,6 +1,6 @@
 import functools
 import xml.etree.ElementTree as ET
-from typing import NamedTuple
+from dataclasses import dataclass
 
 # Models ordered such that models earlier in the list are earlier in the evolution of the token tables
 MODEL_ORDER = {
@@ -42,7 +42,8 @@ MODEL_ORDER = {
 
 
 @functools.total_ordering
-class OsVersion(NamedTuple):
+@dataclass
+class OsVersion:
     model: str
     version: str
 
@@ -197,13 +198,14 @@ class Tokens:
                 token_bits = bits + bytes.fromhex(element.attrib["value"][1:])
                 token = Token.from_element(element, token_bits, version=version)
 
-                all_bytes[token_bits] = token
-                for lang, translation in token.langs.items():
-                    if lang not in all_langs:
-                        all_langs[lang] = {}
+                if token.langs:
+                    all_bytes[token_bits] = token
+                    for lang, translation in token.langs.items():
+                        if lang not in all_langs:
+                            all_langs[lang] = {}
 
-                    for name in translation.names():
-                        all_langs[lang][name] = token_bits
+                        for name in translation.names():
+                            all_langs[lang][name] = token_bits
 
             for child in element:
                 if child.tag == "two-byte":

--- a/scripts/parse.py
+++ b/scripts/parse.py
@@ -1,18 +1,31 @@
 import functools
 import xml.etree.ElementTree as ET
-from collections import namedtuple
+from typing import NamedTuple
 
 # Models ordered such that models earlier in the list are earlier in the evolution of the token tables
 MODEL_ORDER = {
+    "": 0,
+
     "TI-82": 10,
 
     "TI-83": 20,
+    "TI-82ST": 20,
+    "TI-82ST.fr": 20,
+    "TI-76.fr": 20,
 
     "TI-83+": 30,
+    "TI-83+SE": 30,
+    "TI-83+.fr": 30,
+    "TI-82+": 30,
 
     "TI-84+": 40,
-    "TI-84+T": 40,
-    "TI-82A": 40,
+    "TI-84+SE": 40,
+    "TI-83+.fr:USB": 40,
+    "TI-84P.fr": 40,
+    "TI-84+PSE": 40,
+
+    "TI-82A": 45,
+    "TI-84+T": 45,
 
     "TI-84+CSE": 50,
 
@@ -29,8 +42,9 @@ MODEL_ORDER = {
 
 
 @functools.total_ordering
-class OsVersion(namedtuple("OsVersion", ["model", "version"])):
-    __slots__ = ()
+class OsVersion(NamedTuple):
+    model: str
+    version: str
 
     def __lt__(self, other):
         order1 = MODEL_ORDER[self.model]
@@ -46,8 +60,8 @@ class OsVersion(namedtuple("OsVersion", ["model", "version"])):
             elif other.version == "latest":
                 return True
             else:
-                return any(
-                    map(lambda a: a[0] < a[1], zip(map(int, self.version.split(".")), map(int, other.version.split(".")))))
+                return any(map(lambda a: a[0] < a[1],
+                               zip(map(int, self.version.split(".")), map(int, other.version.split(".")))))
 
     def __eq__(self, other):
         return MODEL_ORDER[self.model] == MODEL_ORDER[other.model] and self.version == other.version
@@ -78,6 +92,11 @@ class OsVersion(namedtuple("OsVersion", ["model", "version"])):
                 "Invalid <version> string \"" + version + "\", must be a sequence of numbers separated by periods.")
 
         return OsVersion(model, version)
+
+
+class OsVersions:
+    INITIAL = OsVersion("", "")
+    LATEST = OsVersion("latest", "latest")
 
 
 class Translation:
@@ -114,8 +133,8 @@ class Translation:
 
 class Token:
     def __init__(self, bits: bytes, langs: dict[str, Translation], attrs: dict[str, str] = None,
-                 since: OsVersion = None,
-                 until: OsVersion = None):
+                 since: OsVersion = OsVersions.INITIAL,
+                 until: OsVersion = OsVersions.LATEST):
         self.bits = bits
         self.langs = langs
         self.attrs = attrs
@@ -123,9 +142,9 @@ class Token:
         self.until = until
 
     @staticmethod
-    def from_element(element, bits, version=OsVersion("latest", "")):
-        since = None
-        until = None
+    def from_element(element, bits, version=OsVersions.LATEST):
+        since = OsVersions.INITIAL
+        until = OsVersions.LATEST
 
         langs: dict[str, Translation] = {}
 
@@ -135,7 +154,7 @@ class Token:
                 match child.tag:
                     case "since":
                         version_since = OsVersion.from_element(child)
-                        if since is None:
+                        if since < version_since:
                             since = version_since
 
                         if since > version:
@@ -143,7 +162,7 @@ class Token:
 
                     case "until":
                         version_until = OsVersion.from_element(child)
-                        if until is None or until > version_until:
+                        if until > version_until:
                             until = version_until
 
                     case "lang":
@@ -152,17 +171,18 @@ class Token:
                             langs[code] = translation
         return Token(bits, langs, attrs=element.attrib, since=since, until=until)
 
+
 class Tokens:
-    def __init__(self, bytes, langs):
-        self.bytes = bytes
-        self.langs = langs
+    def __init__(self, byte_map: dict[bytes, Token], lang_map: dict[str, dict[str, bytes]]):
+        self.bytes = byte_map
+        self.langs = lang_map
 
     @staticmethod
-    def from_xml_string(xml_str: str, version=OsVersion("latest", "")):
+    def from_xml_string(xml_str: str, version=OsVersions.LATEST):
         return Tokens.from_element(ET.fromstring(xml_str), version=version)
 
     @staticmethod
-    def from_element(root, version=OsVersion("latest", "")):
+    def from_element(root, version=OsVersions.LATEST):
         if root.tag != "tokens":
             raise ValueError("Not a tokens xml.")
 
@@ -174,15 +194,16 @@ class Tokens:
             nonlocal all_langs
 
             if element.tag == "token":
-                token = Token.from_element(element, bits, version=version)
+                token_bits = bits + bytes.fromhex(element.attrib["value"][1:])
+                token = Token.from_element(element, token_bits, version=version)
 
-                all_bytes[bits] = token
+                all_bytes[token_bits] = token
                 for lang, translation in token.langs.items():
                     if lang not in all_langs:
                         all_langs[lang] = {}
 
                     for name in translation.names():
-                        all_langs[lang][name] = bits
+                        all_langs[lang][name] = token_bits
 
             for child in element:
                 if child.tag == "two-byte":

--- a/scripts/trie.py
+++ b/scripts/trie.py
@@ -28,7 +28,7 @@ class TokenTrie:
 
                 current = current.children[char]
 
-            current.token = tokens.bytes[tokens.langs[lang][name]]
+            current.token = token
 
     @staticmethod
     def from_tokens(tokens: Tokens, lang: str = "en", *, mode: str = "all"):
@@ -44,7 +44,7 @@ class TokenTrie:
     def get_tokens(self, string: str) -> list[tuple[Token, str]]:
         tokens = []
 
-        if string:
+        if string and string[0] in self.children:
             tokens += self.children[string[0]].get_tokens(string[1:])
 
         if self.token:

--- a/scripts/trie.py
+++ b/scripts/trie.py
@@ -1,0 +1,56 @@
+from parse import Token, Tokens
+
+
+class TokenTrie:
+    def __init__(self, token: Token = None):
+        self.token = token
+        self.children = {}
+
+    def insert(self, token: Token, lang: str = "en", *, mode: str = "all"):
+        if lang not in token.langs:
+            raise ValueError(f"lang {lang} not found")
+
+        match mode.lower():
+            case "display":
+                names = [token.langs[lang].display]
+
+            case "accessible":
+                names = [token.langs[lang].accessible]
+
+            case _:
+                names = token.langs[lang].names()
+
+        for name in names:
+            current = self
+            for char in name:
+                if char not in current.children:
+                    current.children[char] = TokenTrie()
+
+                current = current.children[char]
+
+            current.token = tokens.bytes[tokens.langs[lang][name]]
+
+    @staticmethod
+    def from_tokens(tokens: Tokens, lang: str = "en", *, mode: str = "all"):
+        if lang not in tokens.langs:
+            raise ValueError(f"lang {lang} not found")
+
+        root = TokenTrie()
+        for token in tokens.bytes.values():
+            root.insert(token, lang, mode=mode)
+
+        return root
+
+    def get_tokens(self, string: str) -> list[tuple[Token, str]]:
+        tokens = []
+
+        if string:
+            tokens += self.children[string[0]].get_tokens(string[1:])
+
+        if self.token:
+            tokens.append((self.token, string))
+
+        return tokens
+
+    def get_longest_token(self, string: str) -> tuple[Token, str]:
+        return self.get_tokens(string)[0]

--- a/scripts/trie.py
+++ b/scripts/trie.py
@@ -1,4 +1,4 @@
-from parse import Token, Tokens
+from .parse import Token, Tokens
 
 
 class TokenTrie:


### PR DESCRIPTION
Implements three main additions to the scripts:
1. **Previously missing models, particularly all the .fr variants, recognizable by the `OsVersion` struct.** None of the added models appear in the sheets, but can now be used in conjunction with those that do.
2. **A new `OsVersions` enum to hold `INITIAL` and `LATEST` helper constants.** Applications can extend this enum to include other useful version markers like CSE 4.0 or CE 5.6.0.
3. **A new `TokenTrie` class which can construct a trie from a `Tokens` object.** The trie can be used to get all tokens which could be a prefix of a given string more efficiently than looping over `Tokens` directly. Most parsers will use maximal prefixes, so a helper method is included for just the longest token as well. Both methods include the remaining part(s) of the input string in their returns.