### PR TITLE
Add JSON converter

### DIFF
--- a/.github/workflows/.clear-in-built
+++ b/.github/workflows/.clear-in-built
@@ -1,0 +1,2 @@
+.github/*
+scripts/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Run build script
         run: |
           mkdir built
-          cp 73.xml built/
           python -m scripts.build
 
       - name: Upload artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,6 @@ jobs:
   build:
     name: Build and validate token sheets
     runs-on: ubuntu-latest
-    permissions: write-all
 
     if: github.event.pull_request.draft == false
     steps:
@@ -20,6 +19,27 @@ jobs:
         run: |
           mkdir built
           python -m scripts.build
+
+      - name: Upload artifact
+      - uses: actions/upload-artifact@v4
+        with:
+          name: built
+          path: built/
+
+  commit:
+    name: Push sheets to built branch
+    runs-on: ubuntu-latest
+
+    permissions: write-all
+    needs: build
+
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - name: Download artifact
+      - uses: actions/download-artifact@v4
+        with:
+          name: built
+          path: built/
 
       - name: Save to built branch
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ on:
     branches: [ 'main' ]
   pull_request:
     branches: [ 'main' ]
+    types: [opened, synchronize, reopened, ready_for_review]
     
 jobs:
   build:
@@ -10,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
 
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout sheets
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Run build script
         run: |
           mkdir built
+          cp 73.xml built/
           python -m scripts.build
 
       - name: Upload artifact
@@ -47,5 +48,7 @@ jobs:
           REPO: self
           BRANCH: built
           FOLDER: built
+          SKIP_EMPTY_COMMITS: true
+          CLEAR_GLOBS_FILE: ".github/.clear-in-built"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MESSAGE: "Build {sha}: {msg}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
           python -m scripts.build
 
       - name: Upload artifact
-      - uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: built
           path: built/
@@ -36,7 +36,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
       - name: Download artifact
-      - uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4
         with:
           name: built
           path: built/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,18 +5,25 @@ on:
     branches: [ 'main' ]
     
 jobs:
-  validate:
-    name: Validate XML files with XMLStarlet
+  build:
+    name: Build and validate token sheets
     runs-on: ubuntu-latest
+    permissions: write-all
+
     steps:
-      - uses: actions/checkout@v3
-      
-      - name: Validate 73 tokens
-        uses: Mudlet/xmlstarlet-action@v1.1
-        with:
-          args: 'val -b 73.xml'
-          
-      - name: Validate 8X tokens
-        uses: Mudlet/xmlstarlet-action@v1.1
-        with:
-          args: 'val -b 8X.xml'
+      - name: Checkout sheets
+        uses: actions/checkout@v4
+
+      - name: Run build script
+        run: |
+          mkdir built
+          python -m scripts.build
+
+      - name: Save to built branch
+        uses: s0/git-publish-subdir-action@develop
+        env:
+          REPO: self
+          BRANCH: built
+          FOLDER: built
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MESSAGE: "Build {sha}: {msg}"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,4 +1,6 @@
+from .formats import to_json
 from .parse import Token, Tokens, OsVersion, OsVersions, Translation
 from .trie import TokenTrie
 
-__all__ = ["Token", "Tokens", "OsVersion", "OsVersions", "Translation", "TokenTrie"]
+__all__ = ["Token", "Tokens", "OsVersion", "OsVersions", "Translation", "TokenTrie",
+           "to_json"]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,6 +1,6 @@
-from .formats import to_json
+from .formats import to_json, validate
 from .parse import Token, Tokens, OsVersion, OsVersions, Translation
 from .trie import TokenTrie
 
 __all__ = ["Token", "Tokens", "OsVersion", "OsVersions", "Translation", "TokenTrie",
-           "to_json"]
+           "to_json", "validate"]

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,0 +1,15 @@
+import json
+import xml.etree.ElementTree as ET
+
+from .formats import *
+
+
+with open("8X.xml", encoding="UTF-8") as infile:
+    root = ET.fromstring(src := infile.read())
+
+    with open("built/8X.xml", "w+", encoding="UTF-8") as outfile:
+        validate(root)
+        outfile.write(src)
+
+    with open("built/8X.json", "w+", encoding="UTF-8") as outfile:
+        json.dump(to_json(root), outfile, indent=2, ensure_ascii=False)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -13,3 +13,11 @@ with open("8X.xml", encoding="UTF-8") as infile:
 
     with open("built/8X.json", "w+", encoding="UTF-8") as outfile:
         json.dump(to_json(root), outfile, indent=2, ensure_ascii=False)
+
+
+with open("73.xml", encoding="UTF-8") as infile:
+    root = ET.fromstring(src := infile.read())
+
+    with open("built/73.xml", "w+", encoding="UTF-8") as outfile:
+        validate(root, for_73=True)
+        outfile.write(src)

--- a/scripts/formats.py
+++ b/scripts/formats.py
@@ -1,0 +1,62 @@
+import json
+import xml.etree.ElementTree as ET
+
+
+def to_json(element: ET.Element):
+    """
+    Converts a token sheet to an equivalent JSON representation
+
+    :param element: An XML element; call on the root element to convert the entire sheet
+    :return: The element and all its descendants as JSON
+    """
+
+    match element.tag:
+        case "tokens" | "two-byte":
+            return {child.attrib["value"]: to_json(child) for child in element}
+
+        case "token":
+            return [to_json(child) for child in element]
+
+        case "version":
+            dct = {}
+            langs = {}
+
+            for child in element:
+                if child.tag == "lang":
+                    langs[child.attrib["code"]] = to_json(child)
+
+                else:
+                    dct[child.tag] = to_json(child)
+
+            return dct | {"langs": langs}
+
+        case "lang":
+            dct = {"ti-ascii": element.attrib["ti-ascii"]}
+            variants = []
+
+            for child in element:
+                if child.tag == "variant":
+                    variants.append(child.text)
+
+                else:
+                    dct[child.tag] = child.text
+
+            if variants:
+                return dct | {"variants": variants}
+
+            else:
+                return dct
+
+        case _:
+            if list(element):
+                return {child.tag: to_json(child) for child in element}
+
+            else:
+                return element.text
+
+
+# with open("../8X.xml", encoding="UTF-8") as file:
+#   json.dumps(to_json(ET.fromstring(file.read())), indent=2)
+
+
+__all__ = ["to_json"]

--- a/scripts/formats.py
+++ b/scripts/formats.py
@@ -82,9 +82,6 @@ def validate(root: ET.Element) -> int:
                 children(r"<since>(<until>)?(<lang>)+")
 
             case "since":
-                if version != OsVersions.INITIAL:
-                    raise ValidationError("<since> is not first child of <version>")
-
                 if (this_version := OsVersion.from_element(element)) < version:
                     raise ValidationError(f"version {this_version} overlaps with {version}")
 
@@ -95,9 +92,6 @@ def validate(root: ET.Element) -> int:
                 children(r"<model><os-version>")
 
             case "until":
-                if version == OsVersions.INITIAL:
-                    raise ValidationError("<until> precedes <since> in <version>")
-
                 children(r"<model><os-version>")
 
             case "lang":

--- a/scripts/formats.py
+++ b/scripts/formats.py
@@ -1,5 +1,149 @@
 import json
+import re
 import xml.etree.ElementTree as ET
+
+from collections import defaultdict
+
+from .parse import OsVersion, OsVersions
+
+
+def validate(element: ET.Element, byte: str = "", all_tokens: set[str] = None,
+             all_accessible_names: dict[str, set[str]] = None, all_variant_names: dict[str, set[str]] = None):
+    """
+    Validates a token sheet
+
+    :param element: An XML element; call on the root element to validate the entire sheet
+    :param byte: The current token byte (should not be set directly)
+    :param all_tokens: All previously seen tokens (should not be set directly)
+    :param all_accessible_names: All previously seen accessible names per language (should not be set directly)
+    :param all_variant_names: All previously seen variant names per language (should not be set directly)
+    :return: Whether the element and all its descendants are valid components of the sheet
+    """
+
+    byte += element.attrib.get("value", "").lstrip("$")
+
+    all_tokens = all_tokens or set()
+    all_accessible_names = all_accessible_names or defaultdict(set)
+    all_variant_names = all_variant_names or defaultdict(set)
+
+    class ValidationError(ValueError):
+        def __init__(self, message: str):
+            super().__init__("token 0x" + byte + ": " + message if byte else "root: " + message)
+
+    def attributes(el: ET.Element, **attribs: str):
+        for attrib, regex in attribs.items():
+            if attrib not in el.attrib:
+                raise ValidationError(f"<{el.tag}> does not have attribute {attrib}")
+
+            if not re.fullmatch(regex, value := el.attrib[attrib]):
+                raise ValidationError(f"<{el.tag}> {attrib} '{value}' does not match r'{regex}'")
+
+    def children(el: ET.Element, required: list[str], optional: list[str] = ()):
+        options = {*required, *optional}
+        tags = set()
+
+        for child in el:
+            if child.tag not in options:
+                raise ValidationError(f"<{child.tag}> is not a valid child of <{el.tag}>")
+
+            tags.add(child.tag)
+            validate(child, byte, all_tokens, all_accessible_names, all_variant_names)
+
+        if dif := {*required} - tags:
+            raise ValidationError(f"missing required child <{dif.pop()}> of <{el.tag}>")
+
+    def text(el: ET.Element, regex: str):
+        if not re.fullmatch(regex, el.text):
+            raise ValidationError(f"<{el.tag}> text '{el.text}' does not match r'{regex}'")
+
+    match element.tag:
+        case "tokens":
+            children(element, ["token"], ["two-byte"])
+
+        case "two-byte":
+            attributes(element, value=r"\$[0-9A-F]{2}")
+            children(element, ["token"])
+
+        case "token":
+            attributes(element, value=r"\$[0-9A-F]{2}")
+
+            if byte in all_tokens:
+                raise ValidationError("token byte must be unique")
+
+            all_tokens.add(byte)
+
+            accessible_names, variant_names = defaultdict(set), defaultdict(set)
+            current_version = OsVersions.INITIAL
+
+            for version in element:
+                if version.tag != "version":
+                    raise ValidationError(f"<{version.tag}> is not a valid child of <token>")
+
+                tags = set()
+                for grandchild in version:
+                    match grandchild.tag:
+                        case "since":
+                            if (next_version := OsVersion.from_element(grandchild)) < current_version:
+                                raise ValidationError(f"version {next_version} overlaps with {current_version}")
+
+                            children(grandchild, ["model", "os-version"])
+
+                        case "until":
+                            current_version = OsVersion.from_element(grandchild)
+                            children(grandchild, ["model", "os-version"])
+
+                        case "lang":
+                            attributes(grandchild, code=r"[a-z]{2}", **{"ti-ascii": r"([0-9A-F]{2})+"})
+                            lang = grandchild.attrib["code"]
+
+                            names = set()
+                            for name in grandchild:
+                                match name.tag:
+                                    case "display":
+                                        text(name, r"[\S\s]+")
+
+                                    case "accessible":
+                                        text(name, r"[\u0000-\u00FF]*")
+                                        accessible_names[lang].add(name.text)
+
+                                    case "variant":
+                                        text(name, r".+")
+                                        variant_names[lang].add(name.text)
+
+                                    case _:
+                                        ValidationError(f"unrecognized tag <{element.tag}>")
+
+                                names.add(name.tag)
+
+                            if dif := {"display", "accessible"} - names:
+                                raise ValidationError(f"missing required child <{dif.pop()}> of <lang>")
+
+                        case _:
+                            ValidationError(f"unrecognized tag <{element.tag}>")
+
+                    tags.add(grandchild.tag)
+
+                if dif := {"since", "lang"} - tags:
+                    raise ValidationError(f"missing required child <{dif.pop()}> of <version>")
+
+            for lang in accessible_names:
+                if intersection := accessible_names[lang] & all_accessible_names[lang]:
+                    raise ValidationError(f"accessible name '{intersection.pop()}' is not unique")
+
+                if intersection := variant_names[lang] & all_variant_names[lang]:
+                    raise ValidationError(f"variant name '{intersection.pop()}' is not unique")
+
+                all_accessible_names[lang] |= accessible_names[lang]
+                all_variant_names[lang] |= variant_names[lang]
+
+        case "model":
+            text(element, r"TI-\d\d.*")
+
+        case "os-version":
+            text(element, r"(\d+\.)+\d+")
+
+        case _:
+            raise ValidationError(f"unrecognized tag <{element.tag}>")
 
 
 def to_json(element: ET.Element):
@@ -58,5 +202,8 @@ def to_json(element: ET.Element):
 # with open("../8X.xml", encoding="UTF-8") as file:
 #   json.dumps(to_json(ET.fromstring(file.read())), indent=2)
 
+with open("../8X.xml", encoding="UTF-8") as file:
+    validate(ET.fromstring(file.read()))
 
-__all__ = ["to_json"]
+
+__all__ = ["to_json", "validate"]

--- a/scripts/formats.py
+++ b/scripts/formats.py
@@ -7,11 +7,12 @@ from collections import defaultdict
 from .parse import OsVersion, OsVersions
 
 
-def validate(root: ET.Element):
+def validate(root: ET.Element) -> int:
     """
     Validates a token sheet, raising an error if an invalid component is found
 
     :param root: An XML element, which must be the root element of the sheet
+    :return: The number of tokens in the sheet
     """
 
     if root.tag != "tokens":
@@ -69,13 +70,12 @@ def validate(root: ET.Element):
 
             case "token":
                 attributes({"value": r"\$[0-9A-F]{2}"})
+                children(r"(<version>)+")
 
                 if byte in all_tokens:
                     raise ValidationError("token byte must be unique")
 
                 all_tokens.add(byte)
-
-                children(r"(<version>)+")
 
             case "version":
                 version = OsVersions.INITIAL
@@ -137,6 +137,7 @@ def validate(root: ET.Element):
             visit(child, byte, lang)
 
     visit(root)
+    return len(all_tokens)
 
 
 def to_json(element: ET.Element):

--- a/scripts/parse.py
+++ b/scripts/parse.py
@@ -42,7 +42,7 @@ MODEL_ORDER = {
 
 
 @functools.total_ordering
-@dataclass
+@dataclass(frozen=True)
 class OsVersion:
     """
     Data class for defining and comparing OS versions


### PR DESCRIPTION
A straightforward JSON converter function, which doubly serves as a partial format validator. This would be called by CI to deposit the converted sheet in the `built` branch. The file name anticipates more formats, but there are no others I'd advocate for at this very moment.

The JSON format makes unique tags into keys and collects everything else into lists. Each token is a list of `version` dicts, and each translation lives in the version's `langs` dict, indexed by language code. The list of `variants` is not present if it is empty (okay with changing this).