### PR TITLE
Add unique display names as variants

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,4 +49,4 @@ jobs:
           FOLDER: built
           SKIP_EMPTY_COMMITS: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MESSAGE: "Build {sha}: {msg}"
+          MESSAGE: "Build token sheets"

--- a/8X.xml
+++ b/8X.xml
@@ -17,8 +17,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="05444D53">
-				<display>►DMS</display>
+			<lang code="en" ti-ascii="05444D53" display="►DMS">
 				<accessible>&gt;DMS</accessible>
 				<variant>►DMS</variant>
 			</lang>
@@ -30,8 +29,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="05446563">
-				<display>►Dec</display>
+			<lang code="en" ti-ascii="05446563" display="►Dec">
 				<accessible>&gt;Dec</accessible>
 				<variant>►Dec</variant>
 			</lang>
@@ -43,8 +41,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="0546726163">
-				<display>►Frac</display>
+			<lang code="en" ti-ascii="0546726163" display="►Frac">
 				<accessible>&gt;Frac</accessible>
 				<variant>►Frac</variant>
 			</lang>
@@ -56,8 +53,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="1C">
-				<display>→</display>
+			<lang code="en" ti-ascii="1C" display="→">
 				<accessible>-&gt;</accessible>
 				<variant>→</variant>
 			</lang>
@@ -69,8 +65,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="426F78706C6F74">
-				<display>Boxplot</display>
+			<lang code="en" ti-ascii="426F78706C6F74" display="Boxplot">
 				<accessible>Boxplot</accessible>
 			</lang>
 		</version>
@@ -81,8 +76,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="C1">
-				<display>[</display>
+			<lang code="en" ti-ascii="C1" display="[">
 				<accessible>[</accessible>
 			</lang>
 		</version>
@@ -93,8 +87,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5D">
-				<display>]</display>
+			<lang code="en" ti-ascii="5D" display="]">
 				<accessible>]</accessible>
 			</lang>
 		</version>
@@ -105,8 +98,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="7B">
-				<display>{</display>
+			<lang code="en" ti-ascii="7B" display="{">
 				<accessible>{</accessible>
 			</lang>
 		</version>
@@ -117,8 +109,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="7D">
-				<display>}</display>
+			<lang code="en" ti-ascii="7D" display="}">
 				<accessible>}</accessible>
 			</lang>
 		</version>
@@ -129,8 +120,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="15">
-				<display>ʳ</display>
+			<lang code="en" ti-ascii="15" display="ʳ">
 				<accessible>^^r</accessible>
 				<variant>ʳ</variant>
 			</lang>
@@ -142,8 +132,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="14">
-				<display>°</display>
+			<lang code="en" ti-ascii="14" display="°">
 				<accessible>^^o</accessible>
 				<variant>°</variant>
 			</lang>
@@ -155,8 +144,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="11">
-				<display>⁻¹</display>
+			<lang code="en" ti-ascii="11" display="⁻¹">
 				<accessible>^^-1</accessible>
 				<variant>⁻¹</variant>
 				<variant>ˉ¹</variant>
@@ -169,8 +157,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="12">
-				<display>²</display>
+			<lang code="en" ti-ascii="12" display="²">
 				<accessible>^^2</accessible>
 				<variant>²</variant>
 			</lang>
@@ -182,8 +169,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="16">
-				<display>ᵀ</display>
+			<lang code="en" ti-ascii="16" display="ᵀ">
 				<accessible>^^T</accessible>
 				<variant>ᵀ</variant>
 			</lang>
@@ -195,8 +181,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="D5">
-				<display>³</display>
+			<lang code="en" ti-ascii="D5" display="³">
 				<accessible>^^3</accessible>
 				<variant>³</variant>
 			</lang>
@@ -208,8 +193,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="28">
-				<display>(</display>
+			<lang code="en" ti-ascii="28" display="(">
 				<accessible>(</accessible>
 			</lang>
 		</version>
@@ -220,8 +204,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="29">
-				<display>)</display>
+			<lang code="en" ti-ascii="29" display=")">
 				<accessible>)</accessible>
 			</lang>
 		</version>
@@ -232,8 +215,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="726F756E6428">
-				<display>round(</display>
+			<lang code="en" ti-ascii="726F756E6428" display="round(">
 				<accessible>round(</accessible>
 			</lang>
 		</version>
@@ -244,8 +226,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="70786C2D5465737428">
-				<display>pxl-Test(</display>
+			<lang code="en" ti-ascii="70786C2D5465737428" display="pxl-Test(">
 				<accessible>pxl-Test(</accessible>
 			</lang>
 		</version>
@@ -256,8 +237,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="6175676D656E7428">
-				<display>augment(</display>
+			<lang code="en" ti-ascii="6175676D656E7428" display="augment(">
 				<accessible>augment(</accessible>
 			</lang>
 		</version>
@@ -268,8 +248,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="726F775377617028">
-				<display>rowSwap(</display>
+			<lang code="en" ti-ascii="726F775377617028" display="rowSwap(">
 				<accessible>rowSwap(</accessible>
 			</lang>
 		</version>
@@ -280,8 +259,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="726F772B28">
-				<display>row+(</display>
+			<lang code="en" ti-ascii="726F772B28" display="row+(">
 				<accessible>row+(</accessible>
 			</lang>
 		</version>
@@ -292,8 +270,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="2A726F7728">
-				<display>*row(</display>
+			<lang code="en" ti-ascii="2A726F7728" display="*row(">
 				<accessible>*row(</accessible>
 			</lang>
 		</version>
@@ -304,8 +281,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="2A726F772B28">
-				<display>*row+(</display>
+			<lang code="en" ti-ascii="2A726F772B28" display="*row+(">
 				<accessible>*row+(</accessible>
 			</lang>
 		</version>
@@ -316,8 +292,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="6D617828">
-				<display>max(</display>
+			<lang code="en" ti-ascii="6D617828" display="max(">
 				<accessible>max(</accessible>
 			</lang>
 		</version>
@@ -328,8 +303,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="6D696E28">
-				<display>min(</display>
+			<lang code="en" ti-ascii="6D696E28" display="min(">
 				<accessible>min(</accessible>
 			</lang>
 		</version>
@@ -340,8 +314,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5205507228">
-				<display>R►Pr(</display>
+			<lang code="en" ti-ascii="5205507228" display="R►Pr(">
 				<accessible>R&gt;Pr(</accessible>
 				<variant>R►Pr(</variant>
 			</lang>
@@ -353,8 +326,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5205505B28">
-				<display>R►Pθ(</display>
+			<lang code="en" ti-ascii="5205505B28" display="R►Pθ(">
 				<accessible>R&gt;Ptheta(</accessible>
 				<variant>R►Pθ(</variant>
 				<variant>R►Ptheta(</variant>
@@ -368,8 +340,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5005527828">
-				<display>P►Rx(</display>
+			<lang code="en" ti-ascii="5005527828" display="P►Rx(">
 				<accessible>P&gt;Rx(</accessible>
 				<variant>P►Rx(</variant>
 			</lang>
@@ -381,8 +352,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5005527928">
-				<display>P►Ry(</display>
+			<lang code="en" ti-ascii="5005527928" display="P►Ry(">
 				<accessible>P&gt;Ry(</accessible>
 				<variant>P►Ry(</variant>
 			</lang>
@@ -394,8 +364,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="6D656469616E28">
-				<display>median(</display>
+			<lang code="en" ti-ascii="6D656469616E28" display="median(">
 				<accessible>median(</accessible>
 			</lang>
 		</version>
@@ -406,8 +375,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="72616E644D28">
-				<display>randM(</display>
+			<lang code="en" ti-ascii="72616E644D28" display="randM(">
 				<accessible>randM(</accessible>
 			</lang>
 		</version>
@@ -418,8 +386,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="6D65616E28">
-				<display>mean(</display>
+			<lang code="en" ti-ascii="6D65616E28" display="mean(">
 				<accessible>mean(</accessible>
 			</lang>
 		</version>
@@ -430,8 +397,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="736F6C766528">
-				<display>solve(</display>
+			<lang code="en" ti-ascii="736F6C766528" display="solve(">
 				<accessible>solve(</accessible>
 			</lang>
 		</version>
@@ -442,8 +408,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="73657128">
-				<display>seq(</display>
+			<lang code="en" ti-ascii="73657128" display="seq(">
 				<accessible>seq(</accessible>
 			</lang>
 		</version>
@@ -454,8 +419,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="666E496E7428">
-				<display>fnInt(</display>
+			<lang code="en" ti-ascii="666E496E7428" display="fnInt(">
 				<accessible>fnInt(</accessible>
 			</lang>
 		</version>
@@ -466,8 +430,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="6E446572697628">
-				<display>nDeriv(</display>
+			<lang code="en" ti-ascii="6E446572697628" display="nDeriv(">
 				<accessible>nDeriv(</accessible>
 			</lang>
 		</version>
@@ -478,8 +441,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="664D696E28">
-				<display>fMin(</display>
+			<lang code="en" ti-ascii="664D696E28" display="fMin(">
 				<accessible>fMin(</accessible>
 			</lang>
 		</version>
@@ -490,8 +452,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="664D617828">
-				<display>fMax(</display>
+			<lang code="en" ti-ascii="664D617828" display="fMax(">
 				<accessible>fMax(</accessible>
 			</lang>
 		</version>
@@ -502,8 +463,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="20">
-				<display>&#032;</display>
+			<lang code="en" ti-ascii="20" display="&#032;">
 				<accessible>&#032;</accessible>
 			</lang>
 		</version>
@@ -514,8 +474,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="22">
-				<display>&quot;</display>
+			<lang code="en" ti-ascii="22" display="&quot;">
 				<accessible>&quot;</accessible>
 			</lang>
 		</version>
@@ -526,8 +485,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="2C">
-				<display>,</display>
+			<lang code="en" ti-ascii="2C" display=",">
 				<accessible>,</accessible>
 			</lang>
 		</version>
@@ -538,8 +496,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="D7">
-				<display>𝑖</display>
+			<lang code="en" ti-ascii="D7" display="𝑖">
 				<accessible>[i]</accessible>
 				<variant>𝑖</variant>
 			</lang>
@@ -551,8 +508,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="21">
-				<display>!</display>
+			<lang code="en" ti-ascii="21" display="!">
 				<accessible>!</accessible>
 			</lang>
 		</version>
@@ -563,8 +519,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="437562696352656720">
-				<display>CubicReg&#032;</display>
+			<lang code="en" ti-ascii="437562696352656720" display="CubicReg&#032;">
 				<accessible>CubicReg&#032;</accessible>
 			</lang>
 		</version>
@@ -575,8 +530,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="517561727452656720">
-				<display>QuartReg&#032;</display>
+			<lang code="en" ti-ascii="517561727452656720" display="QuartReg&#032;">
 				<accessible>QuartReg&#032;</accessible>
 			</lang>
 		</version>
@@ -587,8 +541,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="30">
-				<display>0</display>
+			<lang code="en" ti-ascii="30" display="0">
 				<accessible>0</accessible>
 			</lang>
 		</version>
@@ -599,8 +552,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="31">
-				<display>1</display>
+			<lang code="en" ti-ascii="31" display="1">
 				<accessible>1</accessible>
 			</lang>
 		</version>
@@ -611,8 +563,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="32">
-				<display>2</display>
+			<lang code="en" ti-ascii="32" display="2">
 				<accessible>2</accessible>
 			</lang>
 		</version>
@@ -623,8 +574,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="33">
-				<display>3</display>
+			<lang code="en" ti-ascii="33" display="3">
 				<accessible>3</accessible>
 			</lang>
 		</version>
@@ -635,8 +585,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="34">
-				<display>4</display>
+			<lang code="en" ti-ascii="34" display="4">
 				<accessible>4</accessible>
 			</lang>
 		</version>
@@ -647,8 +596,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="35">
-				<display>5</display>
+			<lang code="en" ti-ascii="35" display="5">
 				<accessible>5</accessible>
 			</lang>
 		</version>
@@ -659,8 +607,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="36">
-				<display>6</display>
+			<lang code="en" ti-ascii="36" display="6">
 				<accessible>6</accessible>
 			</lang>
 		</version>
@@ -671,8 +618,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="37">
-				<display>7</display>
+			<lang code="en" ti-ascii="37" display="7">
 				<accessible>7</accessible>
 			</lang>
 		</version>
@@ -683,8 +629,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="38">
-				<display>8</display>
+			<lang code="en" ti-ascii="38" display="8">
 				<accessible>8</accessible>
 			</lang>
 		</version>
@@ -695,8 +640,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="39">
-				<display>9</display>
+			<lang code="en" ti-ascii="39" display="9">
 				<accessible>9</accessible>
 			</lang>
 		</version>
@@ -707,8 +651,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="2E">
-				<display>.</display>
+			<lang code="en" ti-ascii="2E" display=".">
 				<accessible>.</accessible>
 			</lang>
 		</version>
@@ -719,8 +662,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="1B">
-				<display>ᴇ</display>
+			<lang code="en" ti-ascii="1B" display="ᴇ">
 				<accessible>|E</accessible>
 				<variant>ᴇ</variant>
 			</lang>
@@ -732,8 +674,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="206F7220">
-				<display>&#032;or&#032;</display>
+			<lang code="en" ti-ascii="206F7220" display="&#032;or&#032;">
 				<accessible>&#032;or&#032;</accessible>
 			</lang>
 		</version>
@@ -744,8 +685,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="20786F7220">
-				<display>&#032;xor&#032;</display>
+			<lang code="en" ti-ascii="20786F7220" display="&#032;xor&#032;">
 				<accessible>&#032;xor&#032;</accessible>
 			</lang>
 		</version>
@@ -756,8 +696,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="3A">
-				<display>:</display>
+			<lang code="en" ti-ascii="3A" display=":">
 				<accessible>:</accessible>
 			</lang>
 		</version>
@@ -768,8 +707,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="D6">
-				<display>&#010;</display>
+			<lang code="en" ti-ascii="D6" display="&#010;">
 				<accessible>&#010;</accessible>
 				<variant>&#013;&#010;</variant>
 			</lang>
@@ -781,8 +719,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="20616E6420">
-				<display>&#032;and&#032;</display>
+			<lang code="en" ti-ascii="20616E6420" display="&#032;and&#032;">
 				<accessible>&#032;and&#032;</accessible>
 			</lang>
 		</version>
@@ -793,8 +730,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="41">
-				<display>A</display>
+			<lang code="en" ti-ascii="41" display="A">
 				<accessible>A</accessible>
 			</lang>
 		</version>
@@ -805,8 +741,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="42">
-				<display>B</display>
+			<lang code="en" ti-ascii="42" display="B">
 				<accessible>B</accessible>
 			</lang>
 		</version>
@@ -817,8 +752,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="43">
-				<display>C</display>
+			<lang code="en" ti-ascii="43" display="C">
 				<accessible>C</accessible>
 			</lang>
 		</version>
@@ -829,8 +763,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="44">
-				<display>D</display>
+			<lang code="en" ti-ascii="44" display="D">
 				<accessible>D</accessible>
 			</lang>
 		</version>
@@ -841,8 +774,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="45">
-				<display>E</display>
+			<lang code="en" ti-ascii="45" display="E">
 				<accessible>E</accessible>
 			</lang>
 		</version>
@@ -853,8 +785,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="46">
-				<display>F</display>
+			<lang code="en" ti-ascii="46" display="F">
 				<accessible>F</accessible>
 			</lang>
 		</version>
@@ -865,8 +796,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="47">
-				<display>G</display>
+			<lang code="en" ti-ascii="47" display="G">
 				<accessible>G</accessible>
 			</lang>
 		</version>
@@ -877,8 +807,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="48">
-				<display>H</display>
+			<lang code="en" ti-ascii="48" display="H">
 				<accessible>H</accessible>
 			</lang>
 		</version>
@@ -889,8 +818,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="49">
-				<display>I</display>
+			<lang code="en" ti-ascii="49" display="I">
 				<accessible>I</accessible>
 			</lang>
 		</version>
@@ -901,8 +829,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4A">
-				<display>J</display>
+			<lang code="en" ti-ascii="4A" display="J">
 				<accessible>J</accessible>
 			</lang>
 		</version>
@@ -913,8 +840,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4B">
-				<display>K</display>
+			<lang code="en" ti-ascii="4B" display="K">
 				<accessible>K</accessible>
 			</lang>
 		</version>
@@ -925,8 +851,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4C">
-				<display>L</display>
+			<lang code="en" ti-ascii="4C" display="L">
 				<accessible>L</accessible>
 			</lang>
 		</version>
@@ -937,8 +862,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4D">
-				<display>M</display>
+			<lang code="en" ti-ascii="4D" display="M">
 				<accessible>M</accessible>
 			</lang>
 		</version>
@@ -949,8 +873,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4E">
-				<display>N</display>
+			<lang code="en" ti-ascii="4E" display="N">
 				<accessible>N</accessible>
 			</lang>
 		</version>
@@ -961,8 +884,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4F">
-				<display>O</display>
+			<lang code="en" ti-ascii="4F" display="O">
 				<accessible>O</accessible>
 			</lang>
 		</version>
@@ -973,8 +895,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="50">
-				<display>P</display>
+			<lang code="en" ti-ascii="50" display="P">
 				<accessible>P</accessible>
 			</lang>
 		</version>
@@ -985,8 +906,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="51">
-				<display>Q</display>
+			<lang code="en" ti-ascii="51" display="Q">
 				<accessible>Q</accessible>
 			</lang>
 		</version>
@@ -997,8 +917,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="52">
-				<display>R</display>
+			<lang code="en" ti-ascii="52" display="R">
 				<accessible>R</accessible>
 			</lang>
 		</version>
@@ -1009,8 +928,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="53">
-				<display>S</display>
+			<lang code="en" ti-ascii="53" display="S">
 				<accessible>S</accessible>
 			</lang>
 		</version>
@@ -1021,8 +939,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="54">
-				<display>T</display>
+			<lang code="en" ti-ascii="54" display="T">
 				<accessible>T</accessible>
 			</lang>
 		</version>
@@ -1033,8 +950,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="55">
-				<display>U</display>
+			<lang code="en" ti-ascii="55" display="U">
 				<accessible>U</accessible>
 			</lang>
 		</version>
@@ -1045,8 +961,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="56">
-				<display>V</display>
+			<lang code="en" ti-ascii="56" display="V">
 				<accessible>V</accessible>
 			</lang>
 		</version>
@@ -1057,8 +972,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="57">
-				<display>W</display>
+			<lang code="en" ti-ascii="57" display="W">
 				<accessible>W</accessible>
 			</lang>
 		</version>
@@ -1069,8 +983,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="58">
-				<display>X</display>
+			<lang code="en" ti-ascii="58" display="X">
 				<accessible>X</accessible>
 			</lang>
 		</version>
@@ -1081,8 +994,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="59">
-				<display>Y</display>
+			<lang code="en" ti-ascii="59" display="Y">
 				<accessible>Y</accessible>
 			</lang>
 		</version>
@@ -1093,8 +1005,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5A">
-				<display>Z</display>
+			<lang code="en" ti-ascii="5A" display="Z">
 				<accessible>Z</accessible>
 			</lang>
 		</version>
@@ -1105,8 +1016,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5B">
-				<display>θ</display>
+			<lang code="en" ti-ascii="5B" display="θ">
 				<accessible>theta</accessible>
 				<variant>θ</variant>
 			</lang>
@@ -1119,8 +1029,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="C1415D">
-					<display>[A]</display>
+				<lang code="en" ti-ascii="C1415D" display="[A]">
 					<accessible>[A]</accessible>
 				</lang>
 			</version>
@@ -1131,8 +1040,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="C1425D">
-					<display>[B]</display>
+				<lang code="en" ti-ascii="C1425D" display="[B]">
 					<accessible>[B]</accessible>
 				</lang>
 			</version>
@@ -1143,8 +1051,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="C1435D">
-					<display>[C]</display>
+				<lang code="en" ti-ascii="C1435D" display="[C]">
 					<accessible>[C]</accessible>
 				</lang>
 			</version>
@@ -1155,8 +1062,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="C1445D">
-					<display>[D]</display>
+				<lang code="en" ti-ascii="C1445D" display="[D]">
 					<accessible>[D]</accessible>
 				</lang>
 			</version>
@@ -1167,8 +1073,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="C1455D">
-					<display>[E]</display>
+				<lang code="en" ti-ascii="C1455D" display="[E]">
 					<accessible>[E]</accessible>
 				</lang>
 			</version>
@@ -1179,8 +1084,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="C1465D">
-					<display>[F]</display>
+				<lang code="en" ti-ascii="C1465D" display="[F]">
 					<accessible>[F]</accessible>
 				</lang>
 			</version>
@@ -1191,8 +1095,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="C1475D">
-					<display>[G]</display>
+				<lang code="en" ti-ascii="C1475D" display="[G]">
 					<accessible>[G]</accessible>
 				</lang>
 			</version>
@@ -1203,8 +1106,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="C1485D">
-					<display>[H]</display>
+				<lang code="en" ti-ascii="C1485D" display="[H]">
 					<accessible>[H]</accessible>
 				</lang>
 			</version>
@@ -1215,8 +1117,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="C1495D">
-					<display>[I]</display>
+				<lang code="en" ti-ascii="C1495D" display="[I]">
 					<accessible>[I]</accessible>
 				</lang>
 			</version>
@@ -1227,8 +1128,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="C14A5D">
-					<display>[J]</display>
+				<lang code="en" ti-ascii="C14A5D" display="[J]">
 					<accessible>[J]</accessible>
 				</lang>
 			</version>
@@ -1241,8 +1141,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4C81">
-					<display>L₁</display>
+				<lang code="en" ti-ascii="4C81" display="L₁">
 					<accessible>L1</accessible>
 					<variant>L₁</variant>
 				</lang>
@@ -1254,8 +1153,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4C82">
-					<display>L₂</display>
+				<lang code="en" ti-ascii="4C82" display="L₂">
 					<accessible>L2</accessible>
 					<variant>L₂</variant>
 				</lang>
@@ -1267,8 +1165,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4C83">
-					<display>L₃</display>
+				<lang code="en" ti-ascii="4C83" display="L₃">
 					<accessible>L3</accessible>
 					<variant>L₃</variant>
 				</lang>
@@ -1280,8 +1177,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4C84">
-					<display>L₄</display>
+				<lang code="en" ti-ascii="4C84" display="L₄">
 					<accessible>L4</accessible>
 					<variant>L₄</variant>
 				</lang>
@@ -1293,8 +1189,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4C85">
-					<display>L₅</display>
+				<lang code="en" ti-ascii="4C85" display="L₅">
 					<accessible>L5</accessible>
 					<variant>L₅</variant>
 				</lang>
@@ -1306,8 +1201,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4C86">
-					<display>L₆</display>
+				<lang code="en" ti-ascii="4C86" display="L₆">
 					<accessible>L6</accessible>
 					<variant>L₆</variant>
 				</lang>
@@ -1321,8 +1215,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5981">
-					<display>Y₁</display>
+				<lang code="en" ti-ascii="5981" display="Y₁">
 					<accessible>{Y1}</accessible>
 					<variant>Y₁</variant>
 				</lang>
@@ -1334,8 +1227,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5983">
-					<display>Y₂</display>
+				<lang code="en" ti-ascii="5983" display="Y₂">
 					<accessible>{Y2}</accessible>
 					<variant>Y₂</variant>
 				</lang>
@@ -1347,8 +1239,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5984">
-					<display>Y₃</display>
+				<lang code="en" ti-ascii="5984" display="Y₃">
 					<accessible>{Y3}</accessible>
 					<variant>Y₃</variant>
 				</lang>
@@ -1360,8 +1251,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5985">
-					<display>Y₄</display>
+				<lang code="en" ti-ascii="5985" display="Y₄">
 					<accessible>{Y4}</accessible>
 					<variant>Y₄</variant>
 				</lang>
@@ -1373,8 +1263,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5986">
-					<display>Y₅</display>
+				<lang code="en" ti-ascii="5986" display="Y₅">
 					<accessible>{Y5}</accessible>
 					<variant>Y₅</variant>
 				</lang>
@@ -1386,8 +1275,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5986">
-					<display>Y₆</display>
+				<lang code="en" ti-ascii="5986" display="Y₆">
 					<accessible>{Y6}</accessible>
 					<variant>Y₆</variant>
 				</lang>
@@ -1399,8 +1287,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5987">
-					<display>Y₇</display>
+				<lang code="en" ti-ascii="5987" display="Y₇">
 					<accessible>{Y7}</accessible>
 					<variant>Y₇</variant>
 				</lang>
@@ -1412,8 +1299,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5988">
-					<display>Y₈</display>
+				<lang code="en" ti-ascii="5988" display="Y₈">
 					<accessible>{Y8}</accessible>
 					<variant>Y₈</variant>
 				</lang>
@@ -1425,8 +1311,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5989">
-					<display>Y₉</display>
+				<lang code="en" ti-ascii="5989" display="Y₉">
 					<accessible>{Y9}</accessible>
 					<variant>Y₉</variant>
 				</lang>
@@ -1438,8 +1323,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5980">
-					<display>Y₀</display>
+				<lang code="en" ti-ascii="5980" display="Y₀">
 					<accessible>{Y0}</accessible>
 					<variant>Y₀</variant>
 				</lang>
@@ -1451,8 +1335,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="58810D">
-					<display>X₁ᴛ</display>
+				<lang code="en" ti-ascii="58810D" display="X₁ᴛ">
 					<accessible>{X1T}</accessible>
 					<variant>X₁ᴛ</variant>
 				</lang>
@@ -1464,8 +1347,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="59810D">
-					<display>Y₁ᴛ</display>
+				<lang code="en" ti-ascii="59810D" display="Y₁ᴛ">
 					<accessible>{Y1T}</accessible>
 					<variant>Y₁ᴛ</variant>
 				</lang>
@@ -1477,8 +1359,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="58820D">
-					<display>X₂ᴛ</display>
+				<lang code="en" ti-ascii="58820D" display="X₂ᴛ">
 					<accessible>{X2T}</accessible>
 					<variant>X₂ᴛ</variant>
 				</lang>
@@ -1490,8 +1371,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="59820D">
-					<display>Y₂ᴛ</display>
+				<lang code="en" ti-ascii="59820D" display="Y₂ᴛ">
 					<accessible>{Y2T}</accessible>
 					<variant>Y₂ᴛ</variant>
 				</lang>
@@ -1503,8 +1383,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="58830D">
-					<display>X₃ᴛ</display>
+				<lang code="en" ti-ascii="58830D" display="X₃ᴛ">
 					<accessible>{X3T}</accessible>
 					<variant>X₃ᴛ</variant>
 				</lang>
@@ -1516,8 +1395,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="59830D">
-					<display>Y₃ᴛ</display>
+				<lang code="en" ti-ascii="59830D" display="Y₃ᴛ">
 					<accessible>{Y3T}</accessible>
 					<variant>Y₃ᴛ</variant>
 				</lang>
@@ -1529,8 +1407,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="58840D">
-					<display>X₄ᴛ</display>
+				<lang code="en" ti-ascii="58840D" display="X₄ᴛ">
 					<accessible>{X4T}</accessible>
 					<variant>X₄ᴛ</variant>
 				</lang>
@@ -1542,8 +1419,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="59840D">
-					<display>Y₄ᴛ</display>
+				<lang code="en" ti-ascii="59840D" display="Y₄ᴛ">
 					<accessible>{Y4T}</accessible>
 					<variant>Y₄ᴛ</variant>
 				</lang>
@@ -1555,8 +1431,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="58850D">
-					<display>X₅ᴛ</display>
+				<lang code="en" ti-ascii="58850D" display="X₅ᴛ">
 					<accessible>{X5T}</accessible>
 					<variant>X₅ᴛ</variant>
 				</lang>
@@ -1568,8 +1443,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="59850D">
-					<display>Y₅ᴛ</display>
+				<lang code="en" ti-ascii="59850D" display="Y₅ᴛ">
 					<accessible>{Y5T}</accessible>
 					<variant>Y₅ᴛ</variant>
 				</lang>
@@ -1581,8 +1455,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="58860D">
-					<display>X₆ᴛ</display>
+				<lang code="en" ti-ascii="58860D" display="X₆ᴛ">
 					<accessible>{X6T}</accessible>
 					<variant>X₆ᴛ</variant>
 				</lang>
@@ -1594,8 +1467,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="59860D">
-					<display>Y₆ᴛ</display>
+				<lang code="en" ti-ascii="59860D" display="Y₆ᴛ">
 					<accessible>{Y6T}</accessible>
 					<variant>Y₆ᴛ</variant>
 				</lang>
@@ -1607,8 +1479,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7281">
-					<display>r₁</display>
+				<lang code="en" ti-ascii="7281" display="r₁">
 					<accessible>{r1}</accessible>
 					<variant>r₁</variant>
 				</lang>
@@ -1620,8 +1491,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7282">
-					<display>r₂</display>
+				<lang code="en" ti-ascii="7282" display="r₂">
 					<accessible>{r2}</accessible>
 					<variant>r₂</variant>
 				</lang>
@@ -1633,8 +1503,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7283">
-					<display>r₃</display>
+				<lang code="en" ti-ascii="7283" display="r₃">
 					<accessible>{r3}</accessible>
 					<variant>r₃</variant>
 				</lang>
@@ -1646,8 +1515,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7284">
-					<display>r₄</display>
+				<lang code="en" ti-ascii="7284" display="r₄">
 					<accessible>{r4}</accessible>
 					<variant>r₄</variant>
 				</lang>
@@ -1659,8 +1527,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7285">
-					<display>r₅</display>
+				<lang code="en" ti-ascii="7285" display="r₅">
 					<accessible>{r5}</accessible>
 					<variant>r₅</variant>
 				</lang>
@@ -1672,8 +1539,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7286">
-					<display>r₆</display>
+				<lang code="en" ti-ascii="7286" display="r₆">
 					<accessible>{r6}</accessible>
 					<variant>r₆</variant>
 				</lang>
@@ -1685,8 +1551,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="75">
-					<display>u</display>
+				<lang code="en" ti-ascii="75" display="u">
 					<accessible>|u</accessible>
 				</lang>
 			</version>
@@ -1697,8 +1562,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="76">
-					<display>v</display>
+				<lang code="en" ti-ascii="76" display="v">
 					<accessible>|v</accessible>
 				</lang>
 			</version>
@@ -1709,8 +1573,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="77">
-					<display>w</display>
+				<lang code="en" ti-ascii="77" display="w">
 					<accessible>|w</accessible>
 				</lang>
 			</version>
@@ -1722,8 +1585,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="7072676D">
-				<display>prgm</display>
+			<lang code="en" ti-ascii="7072676D" display="prgm">
 				<accessible>prgm</accessible>
 			</lang>
 		</version>
@@ -1735,8 +1597,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="50696331">
-					<display>Pic1</display>
+				<lang code="en" ti-ascii="50696331" display="Pic1">
 					<accessible>Pic1</accessible>
 				</lang>
 			</version>
@@ -1747,8 +1608,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="50696332">
-					<display>Pic2</display>
+				<lang code="en" ti-ascii="50696332" display="Pic2">
 					<accessible>Pic2</accessible>
 				</lang>
 			</version>
@@ -1759,8 +1619,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="50696333">
-					<display>Pic3</display>
+				<lang code="en" ti-ascii="50696333" display="Pic3">
 					<accessible>Pic3</accessible>
 				</lang>
 			</version>
@@ -1771,8 +1630,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="50696334">
-					<display>Pic4</display>
+				<lang code="en" ti-ascii="50696334" display="Pic4">
 					<accessible>Pic4</accessible>
 				</lang>
 			</version>
@@ -1783,8 +1641,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="50696335">
-					<display>Pic5</display>
+				<lang code="en" ti-ascii="50696335" display="Pic5">
 					<accessible>Pic5</accessible>
 				</lang>
 			</version>
@@ -1795,8 +1652,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="50696336">
-					<display>Pic6</display>
+				<lang code="en" ti-ascii="50696336" display="Pic6">
 					<accessible>Pic6</accessible>
 				</lang>
 			</version>
@@ -1807,8 +1663,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="50696337">
-					<display>Pic7</display>
+				<lang code="en" ti-ascii="50696337" display="Pic7">
 					<accessible>Pic7</accessible>
 				</lang>
 			</version>
@@ -1819,8 +1674,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="50696338">
-					<display>Pic8</display>
+				<lang code="en" ti-ascii="50696338" display="Pic8">
 					<accessible>Pic8</accessible>
 				</lang>
 			</version>
@@ -1831,8 +1685,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="50696339">
-					<display>Pic9</display>
+				<lang code="en" ti-ascii="50696339" display="Pic9">
 					<accessible>Pic9</accessible>
 				</lang>
 			</version>
@@ -1843,8 +1696,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="50696330">
-					<display>Pic0</display>
+				<lang code="en" ti-ascii="50696330" display="Pic0">
 					<accessible>Pic0</accessible>
 				</lang>
 			</version>
@@ -1857,8 +1709,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="47444231">
-					<display>GDB1</display>
+				<lang code="en" ti-ascii="47444231" display="GDB1">
 					<accessible>GDB1</accessible>
 				</lang>
 			</version>
@@ -1869,8 +1720,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="47444232">
-					<display>GDB2</display>
+				<lang code="en" ti-ascii="47444232" display="GDB2">
 					<accessible>GDB2</accessible>
 				</lang>
 			</version>
@@ -1881,8 +1731,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="47444233">
-					<display>GDB3</display>
+				<lang code="en" ti-ascii="47444233" display="GDB3">
 					<accessible>GDB3</accessible>
 				</lang>
 			</version>
@@ -1893,8 +1742,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="47444234">
-					<display>GDB4</display>
+				<lang code="en" ti-ascii="47444234" display="GDB4">
 					<accessible>GDB4</accessible>
 				</lang>
 			</version>
@@ -1905,8 +1753,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="47444235">
-					<display>GDB5</display>
+				<lang code="en" ti-ascii="47444235" display="GDB5">
 					<accessible>GDB5</accessible>
 				</lang>
 			</version>
@@ -1917,8 +1764,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="47444236">
-					<display>GDB6</display>
+				<lang code="en" ti-ascii="47444236" display="GDB6">
 					<accessible>GDB6</accessible>
 				</lang>
 			</version>
@@ -1929,8 +1775,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="47444237">
-					<display>GDB7</display>
+				<lang code="en" ti-ascii="47444237" display="GDB7">
 					<accessible>GDB7</accessible>
 				</lang>
 			</version>
@@ -1941,8 +1786,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="47444238">
-					<display>GDB8</display>
+				<lang code="en" ti-ascii="47444238" display="GDB8">
 					<accessible>GDB8</accessible>
 				</lang>
 			</version>
@@ -1953,8 +1797,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="47444239">
-					<display>GDB9</display>
+				<lang code="en" ti-ascii="47444239" display="GDB9">
 					<accessible>GDB9</accessible>
 				</lang>
 			</version>
@@ -1965,8 +1808,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="47444230">
-					<display>GDB0</display>
+				<lang code="en" ti-ascii="47444230" display="GDB0">
 					<accessible>GDB0</accessible>
 				</lang>
 			</version>
@@ -1979,8 +1821,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5265674551">
-					<display>RegEQ</display>
+				<lang code="en" ti-ascii="5265674551" display="RegEQ">
 					<accessible>[RegEQ]</accessible>
 					<variant>RegEQ</variant>
 				</lang>
@@ -1992,8 +1833,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="6E">
-					<display>n</display>
+				<lang code="en" ti-ascii="6E" display="n">
 					<accessible>[n]</accessible>
 				</lang>
 			</version>
@@ -2004,8 +1844,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="CB">
-					<display>x̄</display>
+				<lang code="en" ti-ascii="CB" display="x̄">
 					<accessible>[xhat]</accessible>
 					<variant>x̄</variant>
 					<variant>ẋ</variant>
@@ -2018,8 +1857,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="C678">
-					<display>Σx</display>
+				<lang code="en" ti-ascii="C678" display="Σx">
 					<accessible>[Sigmax]</accessible>
 					<variant>Σx</variant>
 				</lang>
@@ -2031,8 +1869,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="C67812">
-					<display>Σx²</display>
+				<lang code="en" ti-ascii="C67812" display="Σx²">
 					<accessible>[Sigmax^2]</accessible>
 					<variant>Σx²</variant>
 					<variant>Σx^2</variant>
@@ -2046,8 +1883,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5378">
-					<display>Sx</display>
+				<lang code="en" ti-ascii="5378" display="Sx">
 					<accessible>[Sx]</accessible>
 					<variant>Sx</variant>
 				</lang>
@@ -2059,8 +1895,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="C778">
-					<display>σx</display>
+				<lang code="en" ti-ascii="C778" display="σx">
 					<accessible>[sigmax]</accessible>
 					<variant>σx</variant>
 				</lang>
@@ -2072,8 +1907,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="6D696E58">
-					<display>minX</display>
+				<lang code="en" ti-ascii="6D696E58" display="minX">
 					<accessible>[minX]</accessible>
 					<variant>minX</variant>
 				</lang>
@@ -2085,8 +1919,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="6D617858">
-					<display>maxX</display>
+				<lang code="en" ti-ascii="6D617858" display="maxX">
 					<accessible>[maxX]</accessible>
 					<variant>maxX</variant>
 				</lang>
@@ -2098,8 +1931,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="6D696E59">
-					<display>minY</display>
+				<lang code="en" ti-ascii="6D696E59" display="minY">
 					<accessible>[minY]</accessible>
 					<variant>minY</variant>
 				</lang>
@@ -2111,8 +1943,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="6D617859">
-					<display>maxY</display>
+				<lang code="en" ti-ascii="6D617859" display="maxY">
 					<accessible>[maxY]</accessible>
 					<variant>maxY</variant>
 				</lang>
@@ -2124,8 +1955,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="CC">
-					<display>ȳ</display>
+				<lang code="en" ti-ascii="CC" display="ȳ">
 					<accessible>[yhat]</accessible>
 					<variant>ȳ</variant>
 				</lang>
@@ -2137,8 +1967,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="C679">
-					<display>Σy</display>
+				<lang code="en" ti-ascii="C679" display="Σy">
 					<accessible>[Sigmay]</accessible>
 					<variant>Σy</variant>
 				</lang>
@@ -2150,8 +1979,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="C67912">
-					<display>Σy²</display>
+				<lang code="en" ti-ascii="C67912" display="Σy²">
 					<accessible>[Sigmay^2]</accessible>
 					<variant>Σy²</variant>
 					<variant>Σy^2</variant>
@@ -2165,8 +1993,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5379">
-					<display>Sy</display>
+				<lang code="en" ti-ascii="5379" display="Sy">
 					<accessible>[Sy]</accessible>
 					<variant>Sy</variant>
 				</lang>
@@ -2178,8 +2005,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="C779">
-					<display>σy</display>
+				<lang code="en" ti-ascii="C779" display="σy">
 					<accessible>[sigmay]</accessible>
 					<variant>σy</variant>
 				</lang>
@@ -2191,8 +2017,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="C67879">
-					<display>Σxy</display>
+				<lang code="en" ti-ascii="C67879" display="Σxy">
 					<accessible>[Sigmaxy]</accessible>
 					<variant>Σxy</variant>
 				</lang>
@@ -2204,8 +2029,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="72">
-					<display>r</display>
+				<lang code="en" ti-ascii="72" display="r">
 					<accessible>[r]</accessible>
 				</lang>
 			</version>
@@ -2216,8 +2040,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4D6564">
-					<display>Med</display>
+				<lang code="en" ti-ascii="4D6564" display="Med">
 					<accessible>[Med]</accessible>
 					<variant>Med</variant>
 				</lang>
@@ -2229,8 +2052,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5181">
-					<display>Q₁</display>
+				<lang code="en" ti-ascii="5181" display="Q₁">
 					<accessible>[Q1]</accessible>
 					<variant>Q₁</variant>
 					<variant>[Q₁]</variant>
@@ -2243,8 +2065,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5183">
-					<display>Q₃</display>
+				<lang code="en" ti-ascii="5183" display="Q₃">
 					<accessible>[Q3]</accessible>
 					<variant>Q₃</variant>
 					<variant>[Q₃]</variant>
@@ -2257,8 +2078,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="61">
-					<display>a</display>
+				<lang code="en" ti-ascii="61" display="a">
 					<accessible>[|a]</accessible>
 				</lang>
 			</version>
@@ -2269,8 +2089,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="62">
-					<display>b</display>
+				<lang code="en" ti-ascii="62" display="b">
 					<accessible>[|b]</accessible>
 				</lang>
 			</version>
@@ -2281,8 +2100,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="63">
-					<display>c</display>
+				<lang code="en" ti-ascii="63" display="c">
 					<accessible>[|c]</accessible>
 				</lang>
 			</version>
@@ -2293,8 +2111,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="64">
-					<display>d</display>
+				<lang code="en" ti-ascii="64" display="d">
 					<accessible>[|d]</accessible>
 				</lang>
 			</version>
@@ -2305,8 +2122,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="65">
-					<display>e</display>
+				<lang code="en" ti-ascii="65" display="e">
 					<accessible>[|e]</accessible>
 				</lang>
 			</version>
@@ -2317,8 +2133,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7881">
-					<display>x₁</display>
+				<lang code="en" ti-ascii="7881" display="x₁">
 					<accessible>[x1]</accessible>
 					<variant>x₁</variant>
 				</lang>
@@ -2330,8 +2145,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7882">
-					<display>x₂</display>
+				<lang code="en" ti-ascii="7882" display="x₂">
 					<accessible>[x2]</accessible>
 					<variant>x₂</variant>
 				</lang>
@@ -2343,8 +2157,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7883">
-					<display>x₃</display>
+				<lang code="en" ti-ascii="7883" display="x₃">
 					<accessible>[x3]</accessible>
 					<variant>x₃</variant>
 				</lang>
@@ -2356,8 +2169,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7981">
-					<display>y₁</display>
+				<lang code="en" ti-ascii="7981" display="y₁">
 					<accessible>[y1]</accessible>
 					<variant>y₁</variant>
 				</lang>
@@ -2369,8 +2181,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7982">
-					<display>y₂</display>
+				<lang code="en" ti-ascii="7982" display="y₂">
 					<accessible>[y2]</accessible>
 					<variant>y₂</variant>
 				</lang>
@@ -2382,8 +2193,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7983">
-					<display>y₃</display>
+				<lang code="en" ti-ascii="7983" display="y₃">
 					<accessible>[y3]</accessible>
 					<variant>y₃</variant>
 				</lang>
@@ -2395,8 +2205,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="01">
-					<display>𝑛</display>
+				<lang code="en" ti-ascii="01" display="𝑛">
 					<accessible>[recursiven]</accessible>
 					<variant>𝑛</variant>
 					<variant>[𝒏]</variant>
@@ -2409,8 +2218,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="70">
-					<display>p</display>
+				<lang code="en" ti-ascii="70" display="p">
 					<accessible>[p]</accessible>
 				</lang>
 			</version>
@@ -2421,8 +2229,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7A">
-					<display>z</display>
+				<lang code="en" ti-ascii="7A" display="z">
 					<accessible>[z]</accessible>
 				</lang>
 			</version>
@@ -2433,8 +2240,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="74">
-					<display>t</display>
+				<lang code="en" ti-ascii="74" display="t">
 					<accessible>[t]</accessible>
 				</lang>
 			</version>
@@ -2445,8 +2251,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="D912">
-					<display>χ²</display>
+				<lang code="en" ti-ascii="D912" display="χ²">
 					<accessible>[chi^2]</accessible>
 					<variant>χ²</variant>
 					<variant>χ^2</variant>
@@ -2460,8 +2265,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="DA">
-					<display>𝙵</display>
+				<lang code="en" ti-ascii="DA" display="𝙵">
 					<accessible>[|F]</accessible>
 				</lang>
 			</version>
@@ -2472,8 +2276,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="6466">
-					<display>df</display>
+				<lang code="en" ti-ascii="6466" display="df">
 					<accessible>[df]</accessible>
 				</lang>
 			</version>
@@ -2484,8 +2287,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="D8">
-					<display>p̂</display>
+				<lang code="en" ti-ascii="D8" display="p̂">
 					<accessible>[phat]</accessible>
 					<variant>[p̂]</variant>
 					<variant>[ṗ]</variant>
@@ -2498,8 +2300,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="D881">
-					<display>p̂₁</display>
+				<lang code="en" ti-ascii="D881" display="p̂₁">
 					<accessible>[phat1]</accessible>
 					<variant>p̂₁</variant>
 					<variant>p̂1</variant>
@@ -2515,8 +2316,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="D882">
-					<display>p̂₂</display>
+				<lang code="en" ti-ascii="D882" display="p̂₂">
 					<accessible>[phat2]</accessible>
 					<variant>p̂₂</variant>
 					<variant>p̂2</variant>
@@ -2532,8 +2332,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="CB81">
-					<display>x̄₁</display>
+				<lang code="en" ti-ascii="CB81" display="x̄₁">
 					<accessible>[xhat1]</accessible>
 					<variant>x̄₁</variant>
 					<variant>ẋ₁</variant>
@@ -2548,8 +2347,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="537881">
-					<display>Sx₁</display>
+				<lang code="en" ti-ascii="537881" display="Sx₁">
 					<accessible>[Sx1]</accessible>
 					<variant>Sx₁</variant>
 				</lang>
@@ -2561,8 +2359,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="6E81">
-					<display>n₁</display>
+				<lang code="en" ti-ascii="6E81" display="n₁">
 					<accessible>[n1]</accessible>
 					<variant>n₁</variant>
 				</lang>
@@ -2574,8 +2371,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="CB82">
-					<display>x̄₂</display>
+				<lang code="en" ti-ascii="CB82" display="x̄₂">
 					<accessible>[xhat2]</accessible>
 					<variant>x̄₂</variant>
 					<variant>x̄2</variant>
@@ -2591,8 +2387,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="537882">
-					<display>Sx₂</display>
+				<lang code="en" ti-ascii="537882" display="Sx₂">
 					<accessible>[Sx2]</accessible>
 					<variant>Sx₂</variant>
 				</lang>
@@ -2604,8 +2399,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="6E82">
-					<display>n₂</display>
+				<lang code="en" ti-ascii="6E82" display="n₂">
 					<accessible>[n2]</accessible>
 					<variant>n₂</variant>
 				</lang>
@@ -2617,8 +2411,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="537870">
-					<display>Sxp</display>
+				<lang code="en" ti-ascii="537870" display="Sxp">
 					<accessible>[Sxp]</accessible>
 					<variant>Sxp</variant>
 				</lang>
@@ -2630,8 +2423,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="6C6F776572">
-					<display>lower</display>
+				<lang code="en" ti-ascii="6C6F776572" display="lower">
 					<accessible>[lower]</accessible>
 					<variant>lower</variant>
 				</lang>
@@ -2643,8 +2435,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7570706572">
-					<display>upper</display>
+				<lang code="en" ti-ascii="7570706572" display="upper">
 					<accessible>[upper]</accessible>
 					<variant>upper</variant>
 				</lang>
@@ -2656,8 +2447,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="73">
-					<display>s</display>
+				<lang code="en" ti-ascii="73" display="s">
 					<accessible>[s]</accessible>
 				</lang>
 			</version>
@@ -2668,8 +2458,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7212">
-					<display>r²</display>
+				<lang code="en" ti-ascii="7212" display="r²">
 					<accessible>[r^2]</accessible>
 					<variant>r²</variant>
 				</lang>
@@ -2681,8 +2470,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5212">
-					<display>R²</display>
+				<lang code="en" ti-ascii="5212" display="R²">
 					<accessible>[R^2]</accessible>
 					<variant>R²</variant>
 				</lang>
@@ -2694,8 +2482,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="6466">
-					<display>df</display>
+				<lang code="en" ti-ascii="6466" display="df">
 					<accessible>[factordf]</accessible>
 				</lang>
 			</version>
@@ -2706,8 +2493,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5353">
-					<display>SS</display>
+				<lang code="en" ti-ascii="5353" display="SS">
 					<accessible>[factorSS]</accessible>
 				</lang>
 			</version>
@@ -2718,8 +2504,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4D53">
-					<display>MS</display>
+				<lang code="en" ti-ascii="4D53" display="MS">
 					<accessible>[factorMS]</accessible>
 				</lang>
 			</version>
@@ -2730,8 +2515,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="6466">
-					<display>df</display>
+				<lang code="en" ti-ascii="6466" display="df">
 					<accessible>[errordf]</accessible>
 				</lang>
 			</version>
@@ -2742,8 +2526,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5353">
-					<display>SS</display>
+				<lang code="en" ti-ascii="5353" display="SS">
 					<accessible>[errorSS]</accessible>
 				</lang>
 			</version>
@@ -2754,8 +2537,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4D53">
-					<display>MS</display>
+				<lang code="en" ti-ascii="4D53" display="MS">
 					<accessible>[errorMS]</accessible>
 				</lang>
 			</version>
@@ -2768,8 +2550,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A5873636C">
-					<display>ZXscl</display>
+				<lang code="en" ti-ascii="5A5873636C" display="ZXscl">
 					<accessible>ZXscl</accessible>
 				</lang>
 			</version>
@@ -2780,8 +2561,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A5973636C">
-					<display>ZYscl</display>
+				<lang code="en" ti-ascii="5A5973636C" display="ZYscl">
 					<accessible>ZYscl</accessible>
 				</lang>
 			</version>
@@ -2792,8 +2572,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5873636C">
-					<display>Xscl</display>
+				<lang code="en" ti-ascii="5873636C" display="Xscl">
 					<accessible>Xscl</accessible>
 				</lang>
 			</version>
@@ -2804,8 +2583,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5973636C">
-					<display>Yscl</display>
+				<lang code="en" ti-ascii="5973636C" display="Yscl">
 					<accessible>Yscl</accessible>
 				</lang>
 			</version>
@@ -2820,8 +2598,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</until>
-				<lang code="en" ti-ascii="556E5374617274">
-					<display>UnStart</display>
+				<lang code="en" ti-ascii="556E5374617274" display="UnStart">
 					<accessible>UnStart</accessible>
 				</lang>
 			</version>
@@ -2830,8 +2607,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="7528014D696E29">
-					<display>u(𝑛Min)</display>
+				<lang code="en" ti-ascii="7528014D696E29" display="u(𝑛Min)">
 					<accessible>u(nMin)</accessible>
 					<variant>u(𝑛Min)</variant>
 					<variant>u(𝒏Min)</variant>
@@ -2848,8 +2624,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</until>
-				<lang code="en" ti-ascii="56015374617274">
-					<display>VnStart</display>
+				<lang code="en" ti-ascii="56015374617274" display="VnStart">
 					<accessible>VnStart</accessible>
 					<variant>V𝒏Start</variant>
 				</lang>
@@ -2859,8 +2634,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="7628014D696E29">
-					<display>v(𝑛Min)</display>
+				<lang code="en" ti-ascii="7628014D696E29" display="v(𝑛Min)">
 					<accessible>v(nMin)</accessible>
 					<variant>v(𝑛Min)</variant>
 					<variant>v(𝒏Min)</variant>
@@ -2877,8 +2651,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</until>
-				<lang code="en" ti-ascii="55012D81">
-					<display>U𝑛-₁</display>
+				<lang code="en" ti-ascii="55012D81" display="U𝑛-₁">
 					<accessible>Un-1</accessible>
 					<variant>U𝑛-₁</variant>
 					<variant>U𝒏-₁</variant>
@@ -2890,8 +2663,7 @@
 					<model>TI-83</model>
 					<os-version>1.010</os-version>
 				</since>
-				<lang code="en" ti-ascii="55012D81">
-					<display>U𝑛-₁</display>
+				<lang code="en" ti-ascii="55012D81" display="U𝑛-₁">
 					<accessible>Un-1</accessible>
 					<variant>U𝑛-₁</variant>
 					<variant>U𝒏-₁</variant>
@@ -2909,8 +2681,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</until>
-				<lang code="en" ti-ascii="56012D81">
-					<display>V𝑛-₁</display>
+				<lang code="en" ti-ascii="56012D81" display="V𝑛-₁">
 					<accessible>Vn-1</accessible>
 					<variant>V𝑛-₁</variant>
 					<variant>V𝒏-₁</variant>
@@ -2922,8 +2693,7 @@
 					<model>TI-83</model>
 					<os-version>1.010</os-version>
 				</since>
-				<lang code="en" ti-ascii="56012D81">
-					<display>V𝑛-₁</display>
+				<lang code="en" ti-ascii="56012D81" display="V𝑛-₁">
 					<accessible>Vn-1</accessible>
 					<variant>V𝑛-₁</variant>
 					<variant>V𝒏-₁</variant>
@@ -2937,8 +2707,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A7528014D696E29">
-					<display>Zu(𝑛Min)</display>
+				<lang code="en" ti-ascii="5A7528014D696E29" display="Zu(𝑛Min)">
 					<accessible>Zu(nMin)</accessible>
 					<variant>Zu(𝑛Min)</variant>
 					<variant>Zu(𝒏Min)</variant>
@@ -2952,8 +2721,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A7628014D696E29">
-					<display>Zv(𝑛Min)</display>
+				<lang code="en" ti-ascii="5A7628014D696E29" display="Zv(𝑛Min)">
 					<accessible>Zv(nMin)</accessible>
 					<variant>Zv(𝑛Min)</variant>
 					<variant>Zv(𝒏Min)</variant>
@@ -2967,8 +2735,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="586D696E">
-					<display>Xmin</display>
+				<lang code="en" ti-ascii="586D696E" display="Xmin">
 					<accessible>Xmin</accessible>
 				</lang>
 			</version>
@@ -2979,8 +2746,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="586D6178">
-					<display>Xmax</display>
+				<lang code="en" ti-ascii="586D6178" display="Xmax">
 					<accessible>Xmax</accessible>
 				</lang>
 			</version>
@@ -2991,8 +2757,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="596D696E">
-					<display>Ymin</display>
+				<lang code="en" ti-ascii="596D696E" display="Ymin">
 					<accessible>Ymin</accessible>
 				</lang>
 			</version>
@@ -3003,8 +2768,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="596D6178">
-					<display>Ymax</display>
+				<lang code="en" ti-ascii="596D6178" display="Ymax">
 					<accessible>Ymax</accessible>
 				</lang>
 			</version>
@@ -3015,8 +2779,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="546D696E">
-					<display>Tmin</display>
+				<lang code="en" ti-ascii="546D696E" display="Tmin">
 					<accessible>Tmin</accessible>
 				</lang>
 			</version>
@@ -3027,8 +2790,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="546D6178">
-					<display>Tmax</display>
+				<lang code="en" ti-ascii="546D6178" display="Tmax">
 					<accessible>Tmax</accessible>
 				</lang>
 			</version>
@@ -3039,8 +2801,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5B6D696E">
-					<display>θmin</display>
+				<lang code="en" ti-ascii="5B6D696E" display="θmin">
 					<accessible>thetaMin</accessible>
 					<variant>θmin</variant>
 					<variant>θMin</variant>
@@ -3053,8 +2814,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5B6D6178">
-					<display>θmax</display>
+				<lang code="en" ti-ascii="5B6D6178" display="θmax">
 					<accessible>thetaMax</accessible>
 					<variant>θmax</variant>
 					<variant>θMax</variant>
@@ -3067,8 +2827,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A586D696E">
-					<display>ZXmin</display>
+				<lang code="en" ti-ascii="5A586D696E" display="ZXmin">
 					<accessible>ZXmin</accessible>
 				</lang>
 			</version>
@@ -3079,8 +2838,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A586D6178">
-					<display>ZXmax</display>
+				<lang code="en" ti-ascii="5A586D6178" display="ZXmax">
 					<accessible>ZXmax</accessible>
 				</lang>
 			</version>
@@ -3091,8 +2849,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A596D696E">
-					<display>ZYmin</display>
+				<lang code="en" ti-ascii="5A596D696E" display="ZYmin">
 					<accessible>ZYmin</accessible>
 				</lang>
 			</version>
@@ -3103,8 +2860,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A596D6178">
-					<display>ZYmax</display>
+				<lang code="en" ti-ascii="5A596D6178" display="ZYmax">
 					<accessible>ZYmax</accessible>
 				</lang>
 			</version>
@@ -3115,8 +2871,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A5B6D696E">
-					<display>Zθmin</display>
+				<lang code="en" ti-ascii="5A5B6D696E" display="Zθmin">
 					<accessible>Zthetamin</accessible>
 					<variant>Zθmin</variant>
 				</lang>
@@ -3128,8 +2883,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A5B6D6178">
-					<display>Zθmax</display>
+				<lang code="en" ti-ascii="5A5B6D6178" display="Zθmax">
 					<accessible>Zthetamax</accessible>
 					<variant>Zθmax</variant>
 				</lang>
@@ -3141,8 +2895,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A546D696E">
-					<display>ZTmin</display>
+				<lang code="en" ti-ascii="5A546D696E" display="ZTmin">
 					<accessible>ZTmin</accessible>
 				</lang>
 			</version>
@@ -3153,8 +2906,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A546D6178">
-					<display>ZTmax</display>
+				<lang code="en" ti-ascii="5A546D6178" display="ZTmax">
 					<accessible>ZTmax</accessible>
 				</lang>
 			</version>
@@ -3165,8 +2917,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="54626C5374617274">
-					<display>TblStart</display>
+				<lang code="en" ti-ascii="54626C5374617274" display="TblStart">
 					<accessible>TblStart</accessible>
 				</lang>
 			</version>
@@ -3181,8 +2932,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</until>
-				<lang code="en" ti-ascii="014D696E">
-					<display>𝑛Min</display>
+				<lang code="en" ti-ascii="014D696E" display="𝑛Min">
 					<accessible>nMin</accessible>
 					<variant>𝑛Min</variant>
 					<variant>𝒏Min</variant>
@@ -3193,8 +2943,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="506C6F745374617274">
-					<display>PlotStart</display>
+				<lang code="en" ti-ascii="506C6F745374617274" display="PlotStart">
 					<accessible>PlotStart</accessible>
 				</lang>
 			</version>
@@ -3205,8 +2954,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A506C6F745374617274">
-					<display>ZPlotStart</display>
+				<lang code="en" ti-ascii="5A506C6F745374617274" display="ZPlotStart">
 					<accessible>ZPlotStart</accessible>
 				</lang>
 			</version>
@@ -3217,8 +2965,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="014D6178">
-					<display>𝑛Max</display>
+				<lang code="en" ti-ascii="014D6178" display="𝑛Max">
 					<accessible>nMax</accessible>
 					<variant>𝑛Max</variant>
 					<variant>𝒏Max</variant>
@@ -3231,8 +2978,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A014D6178">
-					<display>Z𝑛Max</display>
+				<lang code="en" ti-ascii="5A014D6178" display="Z𝑛Max">
 					<accessible>ZnMax</accessible>
 					<variant>Z𝑛Max</variant>
 					<variant>Z𝒏Max</variant>
@@ -3249,8 +2995,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</until>
-				<lang code="en" ti-ascii="015374617274">
-					<display>𝑛Start</display>
+				<lang code="en" ti-ascii="015374617274" display="𝑛Start">
 					<accessible>nStart</accessible>
 					<variant>𝑛Start</variant>
 				</lang>
@@ -3260,8 +3005,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="014D696E">
-					<display>𝑛Min</display>
+				<lang code="en" ti-ascii="014D696E" display="𝑛Min">
 					<accessible>nMin</accessible>
 					<variant>𝑛Min</variant>
 					<variant>𝒏Min</variant>
@@ -3274,8 +3018,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A014D696E">
-					<display>Z𝑛Min</display>
+				<lang code="en" ti-ascii="5A014D696E" display="Z𝑛Min">
 					<accessible>ZnMin</accessible>
 					<variant>Z𝑛Min</variant>
 					<variant>Z𝒏Min</variant>
@@ -3288,8 +3031,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="BE54626C">
-					<display>ΔTbl</display>
+				<lang code="en" ti-ascii="BE54626C" display="ΔTbl">
 					<accessible>DeltaTbl</accessible>
 					<variant>ΔTbl</variant>
 					<variant>∆Tbl</variant>
@@ -3302,8 +3044,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5473746570">
-					<display>Tstep</display>
+				<lang code="en" ti-ascii="5473746570" display="Tstep">
 					<accessible>Tstep</accessible>
 				</lang>
 			</version>
@@ -3314,8 +3055,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5B73746570">
-					<display>θstep</display>
+				<lang code="en" ti-ascii="5B73746570" display="θstep">
 					<accessible>thetastep</accessible>
 					<variant>θstep</variant>
 				</lang>
@@ -3327,8 +3067,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A5473746570">
-					<display>ZTstep</display>
+				<lang code="en" ti-ascii="5A5473746570" display="ZTstep">
 					<accessible>ZTstep</accessible>
 				</lang>
 			</version>
@@ -3339,8 +3078,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A5B73746570">
-					<display>Zθstep</display>
+				<lang code="en" ti-ascii="5A5B73746570" display="Zθstep">
 					<accessible>Zthetastep</accessible>
 					<variant>Zθstep</variant>
 				</lang>
@@ -3352,8 +3090,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="BE58">
-					<display>ΔX</display>
+				<lang code="en" ti-ascii="BE58" display="ΔX">
 					<accessible>DeltaX</accessible>
 					<variant>ΔX</variant>
 					<variant>∆X</variant>
@@ -3366,8 +3103,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="BE59">
-					<display>ΔY</display>
+				<lang code="en" ti-ascii="BE59" display="ΔY">
 					<accessible>DeltaY</accessible>
 					<variant>ΔY</variant>
 					<variant>∆Y</variant>
@@ -3380,8 +3116,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5846616374">
-					<display>XFact</display>
+				<lang code="en" ti-ascii="5846616374" display="XFact">
 					<accessible>XFact</accessible>
 				</lang>
 			</version>
@@ -3392,8 +3127,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5946616374">
-					<display>YFact</display>
+				<lang code="en" ti-ascii="5946616374" display="YFact">
 					<accessible>YFact</accessible>
 				</lang>
 			</version>
@@ -3404,8 +3138,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="54626C496E707574">
-					<display>TblInput</display>
+				<lang code="en" ti-ascii="54626C496E707574" display="TblInput">
 					<accessible>TblInput</accessible>
 				</lang>
 			</version>
@@ -3416,8 +3149,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="DD">
-					<display>𝗡</display>
+				<lang code="en" ti-ascii="DD" display="𝗡">
 					<accessible>|N</accessible>
 					<variant>𝗡</variant>
 					<variant>|𝗡</variant>
@@ -3430,8 +3162,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="4925">
-					<display>I%</display>
+				<lang code="en" ti-ascii="4925" display="I%">
 					<accessible>I%</accessible>
 				</lang>
 			</version>
@@ -3442,8 +3173,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="5056">
-					<display>PV</display>
+				<lang code="en" ti-ascii="5056" display="PV">
 					<accessible>PV</accessible>
 				</lang>
 			</version>
@@ -3454,8 +3184,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="504D54">
-					<display>PMT</display>
+				<lang code="en" ti-ascii="504D54" display="PMT">
 					<accessible>PMT</accessible>
 				</lang>
 			</version>
@@ -3466,8 +3195,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="4656">
-					<display>FV</display>
+				<lang code="en" ti-ascii="4656" display="FV">
 					<accessible>FV</accessible>
 				</lang>
 			</version>
@@ -3478,8 +3206,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="502F59">
-					<display>P/Y</display>
+				<lang code="en" ti-ascii="502F59" display="P/Y">
 					<accessible>|P/Y</accessible>
 					<variant>P/Y</variant>
 				</lang>
@@ -3491,8 +3218,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="432F59">
-					<display>C/Y</display>
+				<lang code="en" ti-ascii="432F59" display="C/Y">
 					<accessible>|C/Y</accessible>
 					<variant>C/Y</variant>
 				</lang>
@@ -3504,8 +3230,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="7728014D696E29">
-					<display>w(𝑛Min)</display>
+				<lang code="en" ti-ascii="7728014D696E29" display="w(𝑛Min)">
 					<accessible>w(nMin)</accessible>
 					<variant>w(𝑛Min)</variant>
 					<variant>w(𝒏Min)</variant>
@@ -3518,8 +3243,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A7728014D696E29">
-					<display>Zw(𝑛Min)</display>
+				<lang code="en" ti-ascii="5A7728014D696E29" display="Zw(𝑛Min)">
 					<accessible>Zw(nMin)</accessible>
 					<variant>Zw(𝑛Min)</variant>
 					<variant>Zw(𝒏Min)</variant>
@@ -3532,8 +3256,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="506C6F7453746570">
-					<display>PlotStep</display>
+				<lang code="en" ti-ascii="506C6F7453746570" display="PlotStep">
 					<accessible>PlotStep</accessible>
 				</lang>
 			</version>
@@ -3544,8 +3267,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A506C6F7453746570">
-					<display>ZPlotStep</display>
+				<lang code="en" ti-ascii="5A506C6F7453746570" display="ZPlotStep">
 					<accessible>ZPlotStep</accessible>
 				</lang>
 			</version>
@@ -3556,8 +3278,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="58726573">
-					<display>Xres</display>
+				<lang code="en" ti-ascii="58726573" display="Xres">
 					<accessible>Xres</accessible>
 				</lang>
 			</version>
@@ -3568,8 +3289,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A58726573">
-					<display>ZXres</display>
+				<lang code="en" ti-ascii="5A58726573" display="ZXres">
 					<accessible>ZXres</accessible>
 				</lang>
 			</version>
@@ -3580,8 +3300,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="547261636553746570">
-					<display>TraceStep</display>
+				<lang code="en" ti-ascii="547261636553746570" display="TraceStep">
 					<accessible>TraceStep</accessible>
 				</lang>
 			</version>
@@ -3593,8 +3312,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="52616469616E">
-				<display>Radian</display>
+			<lang code="en" ti-ascii="52616469616E" display="Radian">
 				<accessible>Radian</accessible>
 			</lang>
 		</version>
@@ -3605,8 +3323,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="446567726565">
-				<display>Degree</display>
+			<lang code="en" ti-ascii="446567726565" display="Degree">
 				<accessible>Degree</accessible>
 			</lang>
 		</version>
@@ -3617,8 +3334,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4E6F726D616C">
-				<display>Normal</display>
+			<lang code="en" ti-ascii="4E6F726D616C" display="Normal">
 				<accessible>Normal</accessible>
 			</lang>
 		</version>
@@ -3629,8 +3345,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="536369">
-				<display>Sci</display>
+			<lang code="en" ti-ascii="536369" display="Sci">
 				<accessible>Sci</accessible>
 			</lang>
 		</version>
@@ -3641,8 +3356,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="456E67">
-				<display>Eng</display>
+			<lang code="en" ti-ascii="456E67" display="Eng">
 				<accessible>Eng</accessible>
 			</lang>
 		</version>
@@ -3653,8 +3367,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="466C6F6174">
-				<display>Float</display>
+			<lang code="en" ti-ascii="466C6F6174" display="Float">
 				<accessible>Float</accessible>
 			</lang>
 		</version>
@@ -3665,8 +3378,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="3D">
-				<display>=</display>
+			<lang code="en" ti-ascii="3D" display="=">
 				<accessible>=</accessible>
 			</lang>
 		</version>
@@ -3677,8 +3389,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="3C">
-				<display>&lt;</display>
+			<lang code="en" ti-ascii="3C" display="&lt;">
 				<accessible>&lt;</accessible>
 			</lang>
 		</version>
@@ -3689,8 +3400,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="3E">
-				<display>&gt;</display>
+			<lang code="en" ti-ascii="3E" display="&gt;">
 				<accessible>&gt;</accessible>
 			</lang>
 		</version>
@@ -3701,8 +3411,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="17">
-				<display>≤</display>
+			<lang code="en" ti-ascii="17" display="≤">
 				<accessible>&lt;=</accessible>
 				<variant>≤</variant>
 			</lang>
@@ -3714,8 +3423,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="19">
-				<display>≥</display>
+			<lang code="en" ti-ascii="19" display="≥">
 				<accessible>&gt;=</accessible>
 				<variant>≥</variant>
 			</lang>
@@ -3727,8 +3435,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="18">
-				<display>≠</display>
+			<lang code="en" ti-ascii="18" display="≠">
 				<accessible>!=</accessible>
 				<variant>≠</variant>
 			</lang>
@@ -3740,8 +3447,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="2B">
-				<display>+</display>
+			<lang code="en" ti-ascii="2B" display="+">
 				<accessible>+</accessible>
 			</lang>
 		</version>
@@ -3752,8 +3458,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="2D">
-				<display>-</display>
+			<lang code="en" ti-ascii="2D" display="-">
 				<accessible>-</accessible>
 			</lang>
 		</version>
@@ -3764,8 +3469,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="416E73">
-				<display>Ans</display>
+			<lang code="en" ti-ascii="416E73" display="Ans">
 				<accessible>Ans</accessible>
 			</lang>
 		</version>
@@ -3776,8 +3480,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="46697820">
-				<display>Fix&#032;</display>
+			<lang code="en" ti-ascii="46697820" display="Fix&#032;">
 				<accessible>Fix&#032;</accessible>
 			</lang>
 		</version>
@@ -3788,8 +3491,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="486F72697A">
-				<display>Horiz</display>
+			<lang code="en" ti-ascii="486F72697A" display="Horiz">
 				<accessible>Horiz</accessible>
 			</lang>
 		</version>
@@ -3800,8 +3502,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="46756C6C">
-				<display>Full</display>
+			<lang code="en" ti-ascii="46756C6C" display="Full">
 				<accessible>Full</accessible>
 			</lang>
 		</version>
@@ -3812,8 +3513,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="46756E63">
-				<display>Func</display>
+			<lang code="en" ti-ascii="46756E63" display="Func">
 				<accessible>Func</accessible>
 			</lang>
 		</version>
@@ -3824,8 +3524,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="506172616D">
-				<display>Param</display>
+			<lang code="en" ti-ascii="506172616D" display="Param">
 				<accessible>Param</accessible>
 			</lang>
 		</version>
@@ -3836,8 +3535,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="506F6C6172">
-				<display>Polar</display>
+			<lang code="en" ti-ascii="506F6C6172" display="Polar">
 				<accessible>Polar</accessible>
 			</lang>
 		</version>
@@ -3848,8 +3546,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="536571">
-				<display>Seq</display>
+			<lang code="en" ti-ascii="536571" display="Seq">
 				<accessible>Seq</accessible>
 			</lang>
 		</version>
@@ -3860,8 +3557,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="496E64706E744175746F">
-				<display>IndpntAuto</display>
+			<lang code="en" ti-ascii="496E64706E744175746F" display="IndpntAuto">
 				<accessible>IndpntAuto</accessible>
 			</lang>
 		</version>
@@ -3872,8 +3568,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="496E64706E7441736B">
-				<display>IndpntAsk</display>
+			<lang code="en" ti-ascii="496E64706E7441736B" display="IndpntAsk">
 				<accessible>IndpntAsk</accessible>
 			</lang>
 		</version>
@@ -3884,8 +3579,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="446570656E644175746F">
-				<display>DependAuto</display>
+			<lang code="en" ti-ascii="446570656E644175746F" display="DependAuto">
 				<accessible>DependAuto</accessible>
 			</lang>
 		</version>
@@ -3896,8 +3590,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="446570656E6441736B">
-				<display>DependAsk</display>
+			<lang code="en" ti-ascii="446570656E6441736B" display="DependAsk">
 				<accessible>DependAsk</accessible>
 			</lang>
 		</version>
@@ -3909,8 +3602,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="53657175656E7469616C">
-					<display>Sequential</display>
+				<lang code="en" ti-ascii="53657175656E7469616C" display="Sequential">
 					<accessible>Sequential</accessible>
 				</lang>
 			</version>
@@ -3921,8 +3613,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="53696D756C">
-					<display>Simul</display>
+				<lang code="en" ti-ascii="53696D756C" display="Simul">
 					<accessible>Simul</accessible>
 				</lang>
 			</version>
@@ -3933,8 +3624,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="506F6C61724743">
-					<display>PolarGC</display>
+				<lang code="en" ti-ascii="506F6C61724743" display="PolarGC">
 					<accessible>PolarGC</accessible>
 				</lang>
 			</version>
@@ -3945,8 +3635,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="526563744743">
-					<display>RectGC</display>
+				<lang code="en" ti-ascii="526563744743" display="RectGC">
 					<accessible>RectGC</accessible>
 				</lang>
 			</version>
@@ -3957,8 +3646,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="436F6F72644F6E">
-					<display>CoordOn</display>
+				<lang code="en" ti-ascii="436F6F72644F6E" display="CoordOn">
 					<accessible>CoordOn</accessible>
 				</lang>
 			</version>
@@ -3969,8 +3657,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="436F6F72644F6666">
-					<display>CoordOff</display>
+				<lang code="en" ti-ascii="436F6F72644F6666" display="CoordOff">
 					<accessible>CoordOff</accessible>
 				</lang>
 			</version>
@@ -3985,8 +3672,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</until>
-				<lang code="en" ti-ascii="436F6E6E6563746564">
-					<display>Connected</display>
+				<lang code="en" ti-ascii="436F6E6E6563746564" display="Connected">
 					<accessible>Connected</accessible>
 				</lang>
 			</version>
@@ -3995,8 +3681,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="546869636B">
-					<display>Thick</display>
+				<lang code="en" ti-ascii="546869636B" display="Thick">
 					<accessible>Thick</accessible>
 				</lang>
 			</version>
@@ -4011,8 +3696,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</until>
-				<lang code="en" ti-ascii="446F74">
-					<display>Dot</display>
+				<lang code="en" ti-ascii="446F74" display="Dot">
 					<accessible>Dot</accessible>
 				</lang>
 			</version>
@@ -4021,8 +3705,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="446F742D546869636B">
-					<display>Dot-Thick</display>
+				<lang code="en" ti-ascii="446F742D546869636B" display="Dot-Thick">
 					<accessible>Dot-Thick</accessible>
 				</lang>
 			</version>
@@ -4037,8 +3720,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</until>
-				<lang code="en" ti-ascii="417865734F6E">
-					<display>AxesOn</display>
+				<lang code="en" ti-ascii="417865734F6E" display="AxesOn">
 					<accessible>AxesOn</accessible>
 				</lang>
 			</version>
@@ -4047,8 +3729,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="417865734F6E20">
-					<display>AxesOn&#032;</display>
+				<lang code="en" ti-ascii="417865734F6E20" display="AxesOn&#032;">
 					<accessible>AxesOn&#032;</accessible>
 				</lang>
 			</version>
@@ -4059,8 +3740,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="417865734F6666">
-					<display>AxesOff</display>
+				<lang code="en" ti-ascii="417865734F6666" display="AxesOff">
 					<accessible>AxesOff</accessible>
 				</lang>
 			</version>
@@ -4075,8 +3755,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</until>
-				<lang code="en" ti-ascii="477269644F6E">
-					<display>GridOn</display>
+				<lang code="en" ti-ascii="477269644F6E" display="GridOn">
 					<accessible>GridOn</accessible>
 				</lang>
 			</version>
@@ -4085,8 +3764,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="47726964446F7420">
-					<display>GridDot&#032;</display>
+				<lang code="en" ti-ascii="47726964446F7420" display="GridDot&#032;">
 					<accessible>GridDot&#032;</accessible>
 				</lang>
 			</version>
@@ -4097,8 +3775,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="477269644F6666">
-					<display>GridOff</display>
+				<lang code="en" ti-ascii="477269644F6666" display="GridOff">
 					<accessible>GridOff</accessible>
 				</lang>
 			</version>
@@ -4109,8 +3786,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4C6162656C4F6E">
-					<display>LabelOn</display>
+				<lang code="en" ti-ascii="4C6162656C4F6E" display="LabelOn">
 					<accessible>LabelOn</accessible>
 				</lang>
 			</version>
@@ -4121,8 +3797,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4C6162656C4F6666">
-					<display>LabelOff</display>
+				<lang code="en" ti-ascii="4C6162656C4F6666" display="LabelOff">
 					<accessible>LabelOff</accessible>
 				</lang>
 			</version>
@@ -4133,8 +3808,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="576562">
-					<display>Web</display>
+				<lang code="en" ti-ascii="576562" display="Web">
 					<accessible>Web</accessible>
 				</lang>
 			</version>
@@ -4145,8 +3819,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="54696D65">
-					<display>Time</display>
+				<lang code="en" ti-ascii="54696D65" display="Time">
 					<accessible>Time</accessible>
 				</lang>
 			</version>
@@ -4157,8 +3830,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="757641786573">
-					<display>uvAxes</display>
+				<lang code="en" ti-ascii="757641786573" display="uvAxes">
 					<accessible>uvAxes</accessible>
 				</lang>
 			</version>
@@ -4169,8 +3841,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="767741786573">
-					<display>vwAxes</display>
+				<lang code="en" ti-ascii="767741786573" display="vwAxes">
 					<accessible>vwAxes</accessible>
 				</lang>
 			</version>
@@ -4181,8 +3852,7 @@
 					<model>TI-82</model>
 					<os-version>1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="53696E52656720">
-					<display>uwAxes</display>
+				<lang code="en" ti-ascii="53696E52656720" display="uwAxes">
 					<accessible>uwAxes</accessible>
 				</lang>
 			</version>
@@ -4194,8 +3864,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="0A">
-				<display>□</display>
+			<lang code="en" ti-ascii="0A" display="□">
 				<accessible>squareplot</accessible>
 				<variant>□</variant>
 				<variant>plotsquare</variant>
@@ -4208,8 +3877,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="0B">
-				<display>﹢</display>
+			<lang code="en" ti-ascii="0B" display="﹢">
 				<accessible>crossplot</accessible>
 				<variant>﹢</variant>
 				<variant>plotcross</variant>
@@ -4222,8 +3890,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="0C">
-				<display>·</display>
+			<lang code="en" ti-ascii="0C" display="·">
 				<accessible>dotplot</accessible>
 				<variant>plotdot</variant>
 			</lang>
@@ -4235,8 +3902,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="2A">
-				<display>*</display>
+			<lang code="en" ti-ascii="2A" display="*">
 				<accessible>*</accessible>
 			</lang>
 		</version>
@@ -4247,8 +3913,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="2F">
-				<display>/</display>
+			<lang code="en" ti-ascii="2F" display="/">
 				<accessible>/</accessible>
 			</lang>
 		</version>
@@ -4259,8 +3924,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5472616365">
-				<display>Trace</display>
+			<lang code="en" ti-ascii="5472616365" display="Trace">
 				<accessible>Trace</accessible>
 			</lang>
 		</version>
@@ -4271,8 +3935,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="436C7244726177">
-				<display>ClrDraw</display>
+			<lang code="en" ti-ascii="436C7244726177" display="ClrDraw">
 				<accessible>ClrDraw</accessible>
 			</lang>
 		</version>
@@ -4283,8 +3946,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5A5374616E64617264">
-				<display>ZStandard</display>
+			<lang code="en" ti-ascii="5A5374616E64617264" display="ZStandard">
 				<accessible>ZStandard</accessible>
 			</lang>
 		</version>
@@ -4295,8 +3957,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5A54726967">
-				<display>ZTrig</display>
+			<lang code="en" ti-ascii="5A54726967" display="ZTrig">
 				<accessible>ZTrig</accessible>
 			</lang>
 		</version>
@@ -4307,8 +3968,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5A426F78">
-				<display>ZBox</display>
+			<lang code="en" ti-ascii="5A426F78" display="ZBox">
 				<accessible>ZBox</accessible>
 			</lang>
 		</version>
@@ -4319,8 +3979,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5A6F6F6D20496E">
-				<display>Zoom In</display>
+			<lang code="en" ti-ascii="5A6F6F6D20496E" display="Zoom In">
 				<accessible>Zoom In</accessible>
 			</lang>
 		</version>
@@ -4331,8 +3990,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5A6F6F6D204F7574">
-				<display>Zoom Out</display>
+			<lang code="en" ti-ascii="5A6F6F6D204F7574" display="Zoom Out">
 				<accessible>Zoom Out</accessible>
 			</lang>
 		</version>
@@ -4343,8 +4001,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5A537175617265">
-				<display>ZSquare</display>
+			<lang code="en" ti-ascii="5A537175617265" display="ZSquare">
 				<accessible>ZSquare</accessible>
 			</lang>
 		</version>
@@ -4355,8 +4012,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5A496E7465676572">
-				<display>ZInteger</display>
+			<lang code="en" ti-ascii="5A496E7465676572" display="ZInteger">
 				<accessible>ZInteger</accessible>
 			</lang>
 		</version>
@@ -4367,8 +4023,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5A50726576696F7573">
-				<display>ZPrevious</display>
+			<lang code="en" ti-ascii="5A50726576696F7573" display="ZPrevious">
 				<accessible>ZPrevious</accessible>
 			</lang>
 		</version>
@@ -4379,8 +4034,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5A446563696D616C">
-				<display>ZDecimal</display>
+			<lang code="en" ti-ascii="5A446563696D616C" display="ZDecimal">
 				<accessible>ZDecimal</accessible>
 			</lang>
 		</version>
@@ -4391,8 +4045,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5A6F6F6D53746174">
-				<display>ZoomStat</display>
+			<lang code="en" ti-ascii="5A6F6F6D53746174" display="ZoomStat">
 				<accessible>ZoomStat</accessible>
 			</lang>
 		</version>
@@ -4403,8 +4056,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5A6F6F6D52636C">
-				<display>ZoomRcl</display>
+			<lang code="en" ti-ascii="5A6F6F6D52636C" display="ZoomRcl">
 				<accessible>ZoomRcl</accessible>
 			</lang>
 		</version>
@@ -4415,8 +4067,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5072696E7453637265656E">
-				<display>PrintScreen</display>
+			<lang code="en" ti-ascii="5072696E7453637265656E" display="PrintScreen">
 				<accessible>PrintScreen</accessible>
 			</lang>
 		</version>
@@ -4427,8 +4078,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5A6F6F6D53746F">
-				<display>ZoomSto</display>
+			<lang code="en" ti-ascii="5A6F6F6D53746F" display="ZoomSto">
 				<accessible>ZoomSto</accessible>
 			</lang>
 		</version>
@@ -4439,8 +4089,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5465787428">
-				<display>Text(</display>
+			<lang code="en" ti-ascii="5465787428" display="Text(">
 				<accessible>Text(</accessible>
 			</lang>
 		</version>
@@ -4451,8 +4100,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="206E507220">
-				<display>&#032;nPr&#032;</display>
+			<lang code="en" ti-ascii="206E507220" display="&#032;nPr&#032;">
 				<accessible>&#032;nPr&#032;</accessible>
 			</lang>
 		</version>
@@ -4463,8 +4111,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="206E437220">
-				<display>&#032;nCr&#032;</display>
+			<lang code="en" ti-ascii="206E437220" display="&#032;nCr&#032;">
 				<accessible>&#032;nCr&#032;</accessible>
 			</lang>
 		</version>
@@ -4475,8 +4122,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="466E4F6E20">
-				<display>FnOn&#032;</display>
+			<lang code="en" ti-ascii="466E4F6E20" display="FnOn&#032;">
 				<accessible>FnOn&#032;</accessible>
 			</lang>
 		</version>
@@ -4487,8 +4133,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="466E4F666620">
-				<display>FnOff&#032;</display>
+			<lang code="en" ti-ascii="466E4F666620" display="FnOff&#032;">
 				<accessible>FnOff&#032;</accessible>
 			</lang>
 		</version>
@@ -4499,8 +4144,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="53746F726550696320">
-				<display>StorePic&#032;</display>
+			<lang code="en" ti-ascii="53746F726550696320" display="StorePic&#032;">
 				<accessible>StorePic&#032;</accessible>
 			</lang>
 		</version>
@@ -4511,8 +4155,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="526563616C6C50696320">
-				<display>RecallPic&#032;</display>
+			<lang code="en" ti-ascii="526563616C6C50696320" display="RecallPic&#032;">
 				<accessible>RecallPic&#032;</accessible>
 			</lang>
 		</version>
@@ -4523,8 +4166,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="53746F726547444220">
-				<display>StoreGDB&#032;</display>
+			<lang code="en" ti-ascii="53746F726547444220" display="StoreGDB&#032;">
 				<accessible>StoreGDB&#032;</accessible>
 			</lang>
 		</version>
@@ -4535,8 +4177,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="526563616C6C47444220">
-				<display>RecallGDB&#032;</display>
+			<lang code="en" ti-ascii="526563616C6C47444220" display="RecallGDB&#032;">
 				<accessible>RecallGDB&#032;</accessible>
 			</lang>
 		</version>
@@ -4547,8 +4188,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4C696E6528">
-				<display>Line(</display>
+			<lang code="en" ti-ascii="4C696E6528" display="Line(">
 				<accessible>Line(</accessible>
 			</lang>
 		</version>
@@ -4559,8 +4199,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="566572746963616C20">
-				<display>Vertical&#032;</display>
+			<lang code="en" ti-ascii="566572746963616C20" display="Vertical&#032;">
 				<accessible>Vertical&#032;</accessible>
 			</lang>
 		</version>
@@ -4571,8 +4210,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="50742D4F6E28">
-				<display>Pt-On(</display>
+			<lang code="en" ti-ascii="50742D4F6E28" display="Pt-On(">
 				<accessible>Pt-On(</accessible>
 			</lang>
 		</version>
@@ -4583,8 +4221,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="50742D4F666628">
-				<display>Pt-Off(</display>
+			<lang code="en" ti-ascii="50742D4F666628" display="Pt-Off(">
 				<accessible>Pt-Off(</accessible>
 			</lang>
 		</version>
@@ -4595,8 +4232,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="50742D4368616E676528">
-				<display>Pt-Change(</display>
+			<lang code="en" ti-ascii="50742D4368616E676528" display="Pt-Change(">
 				<accessible>Pt-Change(</accessible>
 			</lang>
 		</version>
@@ -4607,8 +4243,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="50786C2D4F6E28">
-				<display>Pxl-On(</display>
+			<lang code="en" ti-ascii="50786C2D4F6E28" display="Pxl-On(">
 				<accessible>Pxl-On(</accessible>
 			</lang>
 		</version>
@@ -4619,8 +4254,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="50786C2D4F666628">
-				<display>Pxl-Off(</display>
+			<lang code="en" ti-ascii="50786C2D4F666628" display="Pxl-Off(">
 				<accessible>Pxl-Off(</accessible>
 			</lang>
 		</version>
@@ -4631,8 +4265,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="50786C2D4368616E676528">
-				<display>Pxl-Change(</display>
+			<lang code="en" ti-ascii="50786C2D4368616E676528" display="Pxl-Change(">
 				<accessible>Pxl-Change(</accessible>
 			</lang>
 		</version>
@@ -4643,8 +4276,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="536861646528">
-				<display>Shade(</display>
+			<lang code="en" ti-ascii="536861646528" display="Shade(">
 				<accessible>Shade(</accessible>
 			</lang>
 		</version>
@@ -4655,8 +4287,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="436972636C6528">
-				<display>Circle(</display>
+			<lang code="en" ti-ascii="436972636C6528" display="Circle(">
 				<accessible>Circle(</accessible>
 			</lang>
 		</version>
@@ -4667,8 +4298,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="486F72697A6F6E74616C20">
-				<display>Horizontal&#032;</display>
+			<lang code="en" ti-ascii="486F72697A6F6E74616C20" display="Horizontal&#032;">
 				<accessible>Horizontal&#032;</accessible>
 			</lang>
 		</version>
@@ -4679,8 +4309,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="54616E67656E7428">
-				<display>Tangent(</display>
+			<lang code="en" ti-ascii="54616E67656E7428" display="Tangent(">
 				<accessible>Tangent(</accessible>
 			</lang>
 		</version>
@@ -4691,8 +4320,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="44726177496E7620">
-				<display>DrawInv&#032;</display>
+			<lang code="en" ti-ascii="44726177496E7620" display="DrawInv&#032;">
 				<accessible>DrawInv&#032;</accessible>
 			</lang>
 		</version>
@@ -4703,8 +4331,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="447261774620">
-				<display>DrawF&#032;</display>
+			<lang code="en" ti-ascii="447261774620" display="DrawF&#032;">
 				<accessible>DrawF&#032;</accessible>
 			</lang>
 		</version>
@@ -4716,8 +4343,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="53747231">
-					<display>Str1</display>
+				<lang code="en" ti-ascii="53747231" display="Str1">
 					<accessible>Str1</accessible>
 				</lang>
 			</version>
@@ -4728,8 +4354,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="53747232">
-					<display>Str2</display>
+				<lang code="en" ti-ascii="53747232" display="Str2">
 					<accessible>Str2</accessible>
 				</lang>
 			</version>
@@ -4740,8 +4365,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="53747233">
-					<display>Str3</display>
+				<lang code="en" ti-ascii="53747233" display="Str3">
 					<accessible>Str3</accessible>
 				</lang>
 			</version>
@@ -4752,8 +4376,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="53747234">
-					<display>Str4</display>
+				<lang code="en" ti-ascii="53747234" display="Str4">
 					<accessible>Str4</accessible>
 				</lang>
 			</version>
@@ -4764,8 +4387,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="53747235">
-					<display>Str5</display>
+				<lang code="en" ti-ascii="53747235" display="Str5">
 					<accessible>Str5</accessible>
 				</lang>
 			</version>
@@ -4776,8 +4398,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="53747236">
-					<display>Str6</display>
+				<lang code="en" ti-ascii="53747236" display="Str6">
 					<accessible>Str6</accessible>
 				</lang>
 			</version>
@@ -4788,8 +4409,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="53747237">
-					<display>Str7</display>
+				<lang code="en" ti-ascii="53747237" display="Str7">
 					<accessible>Str7</accessible>
 				</lang>
 			</version>
@@ -4800,8 +4420,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="53747238">
-					<display>Str8</display>
+				<lang code="en" ti-ascii="53747238" display="Str8">
 					<accessible>Str8</accessible>
 				</lang>
 			</version>
@@ -4812,8 +4431,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="53747239">
-					<display>Str9</display>
+				<lang code="en" ti-ascii="53747239" display="Str9">
 					<accessible>Str9</accessible>
 				</lang>
 			</version>
@@ -4824,8 +4442,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="53747230">
-					<display>Str0</display>
+				<lang code="en" ti-ascii="53747230" display="Str0">
 					<accessible>Str0</accessible>
 				</lang>
 			</version>
@@ -4837,8 +4454,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="72616E64">
-				<display>rand</display>
+			<lang code="en" ti-ascii="72616E64" display="rand">
 				<accessible>rand</accessible>
 			</lang>
 		</version>
@@ -4849,8 +4465,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="C4">
-				<display>π</display>
+			<lang code="en" ti-ascii="C4" display="π">
 				<accessible>pi</accessible>
 			</lang>
 		</version>
@@ -4861,8 +4476,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="6765744B6579">
-				<display>getKey</display>
+			<lang code="en" ti-ascii="6765744B6579" display="getKey">
 				<accessible>getKey</accessible>
 			</lang>
 		</version>
@@ -4873,8 +4487,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="27">
-				<display>\&apos;</display>
+			<lang code="en" ti-ascii="27" display="\&apos;">
 				<accessible>&apos;</accessible>
 				<variant>\&apos;</variant>
 			</lang>
@@ -4886,8 +4499,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="3F">
-				<display>?</display>
+			<lang code="en" ti-ascii="3F" display="?">
 				<accessible>?</accessible>
 			</lang>
 		</version>
@@ -4898,8 +4510,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="1A">
-				<display>⁻</display>
+			<lang code="en" ti-ascii="1A" display="⁻">
 				<accessible>~</accessible>
 				<variant>⁻</variant>
 				<variant>|-</variant>
@@ -4916,8 +4527,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="696E7420">
-				<display>int&#032;</display>
+			<lang code="en" ti-ascii="696E7420" display="int&#032;">
 				<accessible>int&#032;</accessible>
 			</lang>
 		</version>
@@ -4926,8 +4536,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="696E7428">
-				<display>int(</display>
+			<lang code="en" ti-ascii="696E7428" display="int(">
 				<accessible>int(</accessible>
 			</lang>
 		</version>
@@ -4942,8 +4551,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="61627320">
-				<display>abs&#032;</display>
+			<lang code="en" ti-ascii="61627320" display="abs&#032;">
 				<accessible>abs&#032;</accessible>
 			</lang>
 		</version>
@@ -4952,8 +4560,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="61627328">
-				<display>abs(</display>
+			<lang code="en" ti-ascii="61627328" display="abs(">
 				<accessible>abs(</accessible>
 			</lang>
 		</version>
@@ -4968,8 +4575,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="64657420">
-				<display>det&#032;</display>
+			<lang code="en" ti-ascii="64657420" display="det&#032;">
 				<accessible>det&#032;</accessible>
 			</lang>
 		</version>
@@ -4978,8 +4584,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="64657428">
-				<display>det(</display>
+			<lang code="en" ti-ascii="64657428" display="det(">
 				<accessible>det(</accessible>
 			</lang>
 		</version>
@@ -4994,8 +4599,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="6964656E7469747920">
-				<display>identity&#032;</display>
+			<lang code="en" ti-ascii="6964656E7469747920" display="identity&#032;">
 				<accessible>identity&#032;</accessible>
 			</lang>
 		</version>
@@ -5004,8 +4608,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="6964656E7469747928">
-				<display>identity(</display>
+			<lang code="en" ti-ascii="6964656E7469747928" display="identity(">
 				<accessible>identity(</accessible>
 			</lang>
 		</version>
@@ -5020,8 +4623,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="64696D20">
-				<display>dim&#032;</display>
+			<lang code="en" ti-ascii="64696D20" display="dim&#032;">
 				<accessible>dim&#032;</accessible>
 			</lang>
 		</version>
@@ -5030,8 +4632,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="64696D28">
-				<display>dim(</display>
+			<lang code="en" ti-ascii="64696D28" display="dim(">
 				<accessible>dim(</accessible>
 			</lang>
 		</version>
@@ -5046,8 +4647,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="73756D20">
-				<display>sum&#032;</display>
+			<lang code="en" ti-ascii="73756D20" display="sum&#032;">
 				<accessible>sum&#032;</accessible>
 			</lang>
 		</version>
@@ -5056,8 +4656,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="73756D28">
-				<display>sum(</display>
+			<lang code="en" ti-ascii="73756D28" display="sum(">
 				<accessible>sum(</accessible>
 			</lang>
 		</version>
@@ -5068,8 +4667,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="70726F6428">
-				<display>prod(</display>
+			<lang code="en" ti-ascii="70726F6428" display="prod(">
 				<accessible>prod(</accessible>
 			</lang>
 		</version>
@@ -5080,8 +4678,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="6E6F7428">
-				<display>not(</display>
+			<lang code="en" ti-ascii="6E6F7428" display="not(">
 				<accessible>not(</accessible>
 			</lang>
 		</version>
@@ -5096,8 +4693,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="695061727420">
-				<display>iPart&#032;</display>
+			<lang code="en" ti-ascii="695061727420" display="iPart&#032;">
 				<accessible>iPart&#032;</accessible>
 			</lang>
 		</version>
@@ -5106,8 +4702,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="695061727428">
-				<display>iPart(</display>
+			<lang code="en" ti-ascii="695061727428" display="iPart(">
 				<accessible>iPart(</accessible>
 			</lang>
 		</version>
@@ -5122,8 +4717,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="665061727420">
-				<display>fPart&#032;</display>
+			<lang code="en" ti-ascii="665061727420" display="fPart&#032;">
 				<accessible>fPart&#032;</accessible>
 			</lang>
 		</version>
@@ -5132,8 +4726,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="665061727428">
-				<display>fPart(</display>
+			<lang code="en" ti-ascii="665061727428" display="fPart(">
 				<accessible>fPart(</accessible>
 			</lang>
 		</version>
@@ -5145,8 +4738,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="6E707628">
-					<display>npv(</display>
+				<lang code="en" ti-ascii="6E707628" display="npv(">
 					<accessible>npv(</accessible>
 				</lang>
 			</version>
@@ -5157,8 +4749,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="69727228">
-					<display>irr(</display>
+				<lang code="en" ti-ascii="69727228" display="irr(">
 					<accessible>irr(</accessible>
 				</lang>
 			</version>
@@ -5169,8 +4760,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="62616C28">
-					<display>bal(</display>
+				<lang code="en" ti-ascii="62616C28" display="bal(">
 					<accessible>bal(</accessible>
 				</lang>
 			</version>
@@ -5181,8 +4771,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="C650726E28">
-					<display>ΣPrn(</display>
+				<lang code="en" ti-ascii="C650726E28" display="ΣPrn(">
 					<accessible>SigmaPrn(</accessible>
 					<variant>ΣPrn(</variant>
 				</lang>
@@ -5194,8 +4783,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="C6496E7428">
-					<display>ΣInt(</display>
+				<lang code="en" ti-ascii="C6496E7428" display="ΣInt(">
 					<accessible>SigmaInt(</accessible>
 					<variant>ΣInt(</variant>
 				</lang>
@@ -5207,8 +4795,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="054E6F6D28">
-					<display>►Nom(</display>
+				<lang code="en" ti-ascii="054E6F6D28" display="►Nom(">
 					<accessible>&gt;Nom(</accessible>
 					<variant>►Nom(</variant>
 				</lang>
@@ -5220,8 +4807,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="0545666628">
-					<display>►Eff(</display>
+				<lang code="en" ti-ascii="0545666628" display="►Eff(">
 					<accessible>&gt;Eff(</accessible>
 					<variant>►Eff(</variant>
 				</lang>
@@ -5233,8 +4819,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="64626428">
-					<display>dbd(</display>
+				<lang code="en" ti-ascii="64626428" display="dbd(">
 					<accessible>dbd(</accessible>
 				</lang>
 			</version>
@@ -5245,8 +4830,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="6C636D28">
-					<display>lcm(</display>
+				<lang code="en" ti-ascii="6C636D28" display="lcm(">
 					<accessible>lcm(</accessible>
 				</lang>
 			</version>
@@ -5257,8 +4841,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="67636428">
-					<display>gcd(</display>
+				<lang code="en" ti-ascii="67636428" display="gcd(">
 					<accessible>gcd(</accessible>
 				</lang>
 			</version>
@@ -5269,8 +4852,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="72616E64496E7428">
-					<display>randInt(</display>
+				<lang code="en" ti-ascii="72616E64496E7428" display="randInt(">
 					<accessible>randInt(</accessible>
 				</lang>
 			</version>
@@ -5281,8 +4863,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="72616E6442696E28">
-					<display>randBin(</display>
+				<lang code="en" ti-ascii="72616E6442696E28" display="randBin(">
 					<accessible>randBin(</accessible>
 				</lang>
 			</version>
@@ -5293,8 +4874,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="73756228">
-					<display>sub(</display>
+				<lang code="en" ti-ascii="73756228" display="sub(">
 					<accessible>sub(</accessible>
 				</lang>
 			</version>
@@ -5305,8 +4885,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="73746444657628">
-					<display>stdDev(</display>
+				<lang code="en" ti-ascii="73746444657628" display="stdDev(">
 					<accessible>stdDev(</accessible>
 				</lang>
 			</version>
@@ -5317,8 +4896,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="76617269616E636528">
-					<display>variance(</display>
+				<lang code="en" ti-ascii="76617269616E636528" display="variance(">
 					<accessible>variance(</accessible>
 				</lang>
 			</version>
@@ -5329,8 +4907,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="696E537472696E6728">
-					<display>inString(</display>
+				<lang code="en" ti-ascii="696E537472696E6728" display="inString(">
 					<accessible>inString(</accessible>
 				</lang>
 			</version>
@@ -5341,8 +4918,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="6E6F726D616C63646628">
-					<display>normalcdf(</display>
+				<lang code="en" ti-ascii="6E6F726D616C63646628" display="normalcdf(">
 					<accessible>normalcdf(</accessible>
 				</lang>
 			</version>
@@ -5353,8 +4929,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="696E764E6F726D28">
-					<display>invNorm(</display>
+				<lang code="en" ti-ascii="696E764E6F726D28" display="invNorm(">
 					<accessible>invNorm(</accessible>
 				</lang>
 			</version>
@@ -5365,8 +4940,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="7463646628">
-					<display>tcdf(</display>
+				<lang code="en" ti-ascii="7463646628" display="tcdf(">
 					<accessible>tcdf(</accessible>
 				</lang>
 			</version>
@@ -5377,8 +4951,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="D91263646628">
-					<display>χ²cdf(</display>
+				<lang code="en" ti-ascii="D91263646628" display="χ²cdf(">
 					<accessible>chi^2cdf(</accessible>
 					<variant>χ²cdf(</variant>
 					<variant>χ^2cdf(</variant>
@@ -5392,8 +4965,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="DA63646628">
-					<display>𝙵cdf(</display>
+				<lang code="en" ti-ascii="DA63646628" display="𝙵cdf(">
 					<accessible>Fcdf(</accessible>
 					<variant>𝙵cdf(</variant>
 					<variant>𝐅cdf(</variant>
@@ -5406,8 +4978,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="62696E6F6D70646628">
-					<display>binompdf(</display>
+				<lang code="en" ti-ascii="62696E6F6D70646628" display="binompdf(">
 					<accessible>binompdf(</accessible>
 				</lang>
 			</version>
@@ -5418,8 +4989,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="62696E6F6D63646628">
-					<display>binomcdf(</display>
+				<lang code="en" ti-ascii="62696E6F6D63646628" display="binomcdf(">
 					<accessible>binomcdf(</accessible>
 				</lang>
 			</version>
@@ -5430,8 +5000,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="706F6973736F6E70646628">
-					<display>poissonpdf(</display>
+				<lang code="en" ti-ascii="706F6973736F6E70646628" display="poissonpdf(">
 					<accessible>poissonpdf(</accessible>
 				</lang>
 			</version>
@@ -5442,8 +5011,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="706F6973736F6E63646628">
-					<display>poissoncdf(</display>
+				<lang code="en" ti-ascii="706F6973736F6E63646628" display="poissoncdf(">
 					<accessible>poissoncdf(</accessible>
 				</lang>
 			</version>
@@ -5454,8 +5022,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="67656F6D657470646628">
-					<display>geometpdf(</display>
+				<lang code="en" ti-ascii="67656F6D657470646628" display="geometpdf(">
 					<accessible>geometpdf(</accessible>
 				</lang>
 			</version>
@@ -5466,8 +5033,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="67656F6D657463646628">
-					<display>geometcdf(</display>
+				<lang code="en" ti-ascii="67656F6D657463646628" display="geometcdf(">
 					<accessible>geometcdf(</accessible>
 				</lang>
 			</version>
@@ -5478,8 +5044,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="6E6F726D616C70646628">
-					<display>normalpdf(</display>
+				<lang code="en" ti-ascii="6E6F726D616C70646628" display="normalpdf(">
 					<accessible>normalpdf(</accessible>
 				</lang>
 			</version>
@@ -5490,8 +5055,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="7470646628">
-					<display>tpdf(</display>
+				<lang code="en" ti-ascii="7470646628" display="tpdf(">
 					<accessible>tpdf(</accessible>
 				</lang>
 			</version>
@@ -5502,8 +5066,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="D91270646628">
-					<display>χ²pdf(</display>
+				<lang code="en" ti-ascii="D91270646628" display="χ²pdf(">
 					<accessible>chi^2pdf(</accessible>
 					<variant>χ²pdf(</variant>
 					<variant>χ^2pdf(</variant>
@@ -5517,8 +5080,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="DA70646628">
-					<display>𝙵pdf(</display>
+				<lang code="en" ti-ascii="DA70646628" display="𝙵pdf(">
 					<accessible>Fpdf(</accessible>
 					<variant>𝙵pdf(</variant>
 					<variant>𝐅pdf(</variant>
@@ -5531,8 +5093,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="72616E644E6F726D28">
-					<display>randNorm(</display>
+				<lang code="en" ti-ascii="72616E644E6F726D28" display="randNorm(">
 					<accessible>randNorm(</accessible>
 				</lang>
 			</version>
@@ -5543,8 +5104,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="74766D5F506D74">
-					<display>tvm_Pmt</display>
+				<lang code="en" ti-ascii="74766D5F506D74" display="tvm_Pmt">
 					<accessible>tvm_Pmt</accessible>
 				</lang>
 			</version>
@@ -5555,8 +5115,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="74766D5F4925">
-					<display>tvm_I%</display>
+				<lang code="en" ti-ascii="74766D5F4925" display="tvm_I%">
 					<accessible>tvm_I%</accessible>
 				</lang>
 			</version>
@@ -5567,8 +5126,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="74766D5F5056">
-					<display>tvm_PV</display>
+				<lang code="en" ti-ascii="74766D5F5056" display="tvm_PV">
 					<accessible>tvm_PV</accessible>
 				</lang>
 			</version>
@@ -5579,8 +5137,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="74766D5FDD">
-					<display>tvm_𝗡</display>
+				<lang code="en" ti-ascii="74766D5FDD" display="tvm_𝗡">
 					<accessible>tvm_N</accessible>
 					<variant>tvm_𝗡</variant>
 				</lang>
@@ -5592,8 +5149,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="74766D5F4656">
-					<display>tvm_FV</display>
+				<lang code="en" ti-ascii="74766D5F4656" display="tvm_FV">
 					<accessible>tvm_FV</accessible>
 				</lang>
 			</version>
@@ -5604,8 +5160,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="636F6E6A28">
-					<display>conj(</display>
+				<lang code="en" ti-ascii="636F6E6A28" display="conj(">
 					<accessible>conj(</accessible>
 				</lang>
 			</version>
@@ -5616,8 +5171,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="7265616C28">
-					<display>real(</display>
+				<lang code="en" ti-ascii="7265616C28" display="real(">
 					<accessible>real(</accessible>
 				</lang>
 			</version>
@@ -5628,8 +5182,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="696D616728">
-					<display>imag(</display>
+				<lang code="en" ti-ascii="696D616728" display="imag(">
 					<accessible>imag(</accessible>
 				</lang>
 			</version>
@@ -5640,8 +5193,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="616E676C6528">
-					<display>angle(</display>
+				<lang code="en" ti-ascii="616E676C6528" display="angle(">
 					<accessible>angle(</accessible>
 				</lang>
 			</version>
@@ -5652,8 +5204,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="63756D53756D28">
-					<display>cumSum(</display>
+				<lang code="en" ti-ascii="63756D53756D28" display="cumSum(">
 					<accessible>cumSum(</accessible>
 				</lang>
 			</version>
@@ -5664,8 +5215,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="6578707228">
-					<display>expr(</display>
+				<lang code="en" ti-ascii="6578707228" display="expr(">
 					<accessible>expr(</accessible>
 				</lang>
 			</version>
@@ -5676,8 +5226,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="6C656E67746828">
-					<display>length(</display>
+				<lang code="en" ti-ascii="6C656E67746828" display="length(">
 					<accessible>length(</accessible>
 				</lang>
 			</version>
@@ -5688,8 +5237,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="BE4C69737428">
-					<display>ΔList(</display>
+				<lang code="en" ti-ascii="BE4C69737428" display="ΔList(">
 					<accessible>DeltaList(</accessible>
 					<variant>ΔList(</variant>
 				</lang>
@@ -5701,8 +5249,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="72656628">
-					<display>ref(</display>
+				<lang code="en" ti-ascii="72656628" display="ref(">
 					<accessible>ref(</accessible>
 				</lang>
 			</version>
@@ -5713,8 +5260,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="7272656628">
-					<display>rref(</display>
+				<lang code="en" ti-ascii="7272656628" display="rref(">
 					<accessible>rref(</accessible>
 				</lang>
 			</version>
@@ -5725,8 +5271,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="0552656374">
-					<display>►Rect</display>
+				<lang code="en" ti-ascii="0552656374" display="►Rect">
 					<accessible>&gt;Rect</accessible>
 					<variant>►Rect</variant>
 				</lang>
@@ -5738,8 +5283,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="05506F6C6172">
-					<display>►Polar</display>
+				<lang code="en" ti-ascii="05506F6C6172" display="►Polar">
 					<accessible>&gt;Polar</accessible>
 					<variant>►Polar</variant>
 				</lang>
@@ -5751,8 +5295,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="DB">
-					<display>𝑒</display>
+				<lang code="en" ti-ascii="DB" display="𝑒">
 					<accessible>[e]</accessible>
 					<variant>𝑒</variant>
 				</lang>
@@ -5764,8 +5307,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="53696E52656720">
-					<display>SinReg&#032;</display>
+				<lang code="en" ti-ascii="53696E52656720" display="SinReg&#032;">
 					<accessible>SinReg&#032;</accessible>
 				</lang>
 			</version>
@@ -5776,8 +5318,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="4C6F67697374696320">
-					<display>Logistic&#032;</display>
+				<lang code="en" ti-ascii="4C6F67697374696320" display="Logistic&#032;">
 					<accessible>Logistic&#032;</accessible>
 				</lang>
 			</version>
@@ -5788,8 +5329,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="4C696E526567545465737420">
-					<display>LinRegTTest&#032;</display>
+				<lang code="en" ti-ascii="4C696E526567545465737420" display="LinRegTTest&#032;">
 					<accessible>LinRegTTest&#032;</accessible>
 				</lang>
 			</version>
@@ -5800,8 +5340,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="53686164654E6F726D28">
-					<display>ShadeNorm(</display>
+				<lang code="en" ti-ascii="53686164654E6F726D28" display="ShadeNorm(">
 					<accessible>ShadeNorm(</accessible>
 				</lang>
 			</version>
@@ -5812,8 +5351,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="53686164655F7428">
-					<display>Shade_t(</display>
+				<lang code="en" ti-ascii="53686164655F7428" display="Shade_t(">
 					<accessible>Shade_t(</accessible>
 				</lang>
 			</version>
@@ -5824,8 +5362,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="5368616465D91228">
-					<display>Shadeχ²(</display>
+				<lang code="en" ti-ascii="5368616465D91228" display="Shadeχ²(">
 					<accessible>Shadechi^2(</accessible>
 					<variant>Shadeχ²(</variant>
 					<variant>Shadeχ^2(</variant>
@@ -5839,8 +5376,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="5368616465DA28BB39">
-					<display>Shade𝙵(</display>
+				<lang code="en" ti-ascii="5368616465DA28BB39" display="Shade𝙵(">
 					<accessible>ShadeF(</accessible>
 					<variant>Shade𝙵(</variant>
 					<variant>Shade𝐅(</variant>
@@ -5853,8 +5389,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="4D617472056C69737428">
-					<display>Matr►list(</display>
+				<lang code="en" ti-ascii="4D617472056C69737428" display="Matr►list(">
 					<accessible>Matr&gt;list(</accessible>
 					<variant>Matr►list(</variant>
 				</lang>
@@ -5866,8 +5401,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="4C697374056D61747228">
-					<display>List►matr(</display>
+				<lang code="en" ti-ascii="4C697374056D61747228" display="List►matr(">
 					<accessible>List&gt;matr(</accessible>
 					<variant>List►matr(</variant>
 				</lang>
@@ -5879,8 +5413,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A2D5465737428">
-					<display>Z-Test(</display>
+				<lang code="en" ti-ascii="5A2D5465737428" display="Z-Test(">
 					<accessible>Z-Test(</accessible>
 				</lang>
 			</version>
@@ -5891,8 +5424,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="542D5465737420">
-					<display>T-Test&#032;</display>
+				<lang code="en" ti-ascii="542D5465737420" display="T-Test&#032;">
 					<accessible>T-Test&#032;</accessible>
 				</lang>
 			</version>
@@ -5903,8 +5435,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="322D53616D705A5465737428">
-					<display>2-SampZTest(</display>
+				<lang code="en" ti-ascii="322D53616D705A5465737428" display="2-SampZTest(">
 					<accessible>2-SampZTest(</accessible>
 				</lang>
 			</version>
@@ -5915,8 +5446,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="312D50726F705A5465737428">
-					<display>1-PropZTest(</display>
+				<lang code="en" ti-ascii="312D50726F705A5465737428" display="1-PropZTest(">
 					<accessible>1-PropZTest(</accessible>
 				</lang>
 			</version>
@@ -5927,8 +5457,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="322D50726F705A5465737428">
-					<display>2-PropZTest(</display>
+				<lang code="en" ti-ascii="322D50726F705A5465737428" display="2-PropZTest(">
 					<accessible>2-PropZTest(</accessible>
 				</lang>
 			</version>
@@ -5939,8 +5468,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="D9122D5465737428">
-					<display>χ²-Test(</display>
+				<lang code="en" ti-ascii="D9122D5465737428" display="χ²-Test(">
 					<accessible>chi^2-Test(</accessible>
 					<variant>χ²-Test(</variant>
 					<variant>χ^2-Test(</variant>
@@ -5954,8 +5482,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A496E74657276616C20">
-					<display>ZInterval&#032;</display>
+				<lang code="en" ti-ascii="5A496E74657276616C20" display="ZInterval&#032;">
 					<accessible>ZInterval&#032;</accessible>
 				</lang>
 			</version>
@@ -5966,8 +5493,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="322D53616D705A496E7428">
-					<display>2-SampZInt(</display>
+				<lang code="en" ti-ascii="322D53616D705A496E7428" display="2-SampZInt(">
 					<accessible>2-SampZInt(</accessible>
 				</lang>
 			</version>
@@ -5978,8 +5504,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="312D50726F705A496E7428">
-					<display>1-PropZInt(</display>
+				<lang code="en" ti-ascii="312D50726F705A496E7428" display="1-PropZInt(">
 					<accessible>1-PropZInt(</accessible>
 				</lang>
 			</version>
@@ -5990,8 +5515,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="322D50726F705A496E7428">
-					<display>2-PropZInt(</display>
+				<lang code="en" ti-ascii="322D50726F705A496E7428" display="2-PropZInt(">
 					<accessible>2-PropZInt(</accessible>
 				</lang>
 			</version>
@@ -6002,8 +5526,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="47726170685374796C6528">
-					<display>GraphStyle(</display>
+				<lang code="en" ti-ascii="47726170685374796C6528" display="GraphStyle(">
 					<accessible>GraphStyle(</accessible>
 				</lang>
 			</version>
@@ -6014,8 +5537,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="322D53616D70545465737420">
-					<display>2-SampTTest&#032;</display>
+				<lang code="en" ti-ascii="322D53616D70545465737420" display="2-SampTTest&#032;">
 					<accessible>2-SampTTest&#032;</accessible>
 				</lang>
 			</version>
@@ -6026,8 +5548,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="322D53616D70DA5465737420">
-					<display>2-Samp𝙵Test&#032;</display>
+				<lang code="en" ti-ascii="322D53616D70DA5465737420" display="2-Samp𝙵Test&#032;">
 					<accessible>2-SampFTest&#032;</accessible>
 					<variant>2-Samp𝙵Test&#032;</variant>
 					<variant>2-Samp𝐅Test&#032;</variant>
@@ -6040,8 +5561,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="54496E74657276616C20">
-					<display>TInterval&#032;</display>
+				<lang code="en" ti-ascii="54496E74657276616C20" display="TInterval&#032;">
 					<accessible>TInterval&#032;</accessible>
 				</lang>
 			</version>
@@ -6052,8 +5572,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="322D53616D7054496E7420">
-					<display>2-SampTInt&#032;</display>
+				<lang code="en" ti-ascii="322D53616D7054496E7420" display="2-SampTInt&#032;">
 					<accessible>2-SampTInt&#032;</accessible>
 				</lang>
 			</version>
@@ -6064,8 +5583,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="5365745570456469746F7220">
-					<display>SetUpEditor&#032;</display>
+				<lang code="en" ti-ascii="5365745570456469746F7220" display="SetUpEditor&#032;">
 					<accessible>SetUpEditor&#032;</accessible>
 				</lang>
 			</version>
@@ -6076,8 +5594,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="506D745F456E64">
-					<display>Pmt_End</display>
+				<lang code="en" ti-ascii="506D745F456E64" display="Pmt_End">
 					<accessible>Pmt_End</accessible>
 				</lang>
 			</version>
@@ -6088,8 +5605,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="506D745F42676E">
-					<display>Pmt_Bgn</display>
+				<lang code="en" ti-ascii="506D745F42676E" display="Pmt_Bgn">
 					<accessible>Pmt_Bgn</accessible>
 				</lang>
 			</version>
@@ -6100,8 +5616,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="5265616C">
-					<display>Real</display>
+				<lang code="en" ti-ascii="5265616C" display="Real">
 					<accessible>Real</accessible>
 				</lang>
 			</version>
@@ -6112,8 +5627,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="72DB5E5BD7">
-					<display>r𝑒^θ𝑖</display>
+				<lang code="en" ti-ascii="72DB5E5BD7" display="r𝑒^θ𝑖">
 					<accessible>re^thetai</accessible>
 					<variant>r𝑒^θ𝑖</variant>
 					<variant>re^θ𝑖</variant>
@@ -6128,8 +5642,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="612B62D7">
-					<display>a+b𝑖</display>
+				<lang code="en" ti-ascii="612B62D7" display="a+b𝑖">
 					<accessible>a+bi</accessible>
 					<variant>a+b𝑖</variant>
 				</lang>
@@ -6141,8 +5654,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="457870724F6E">
-					<display>ExprOn</display>
+				<lang code="en" ti-ascii="457870724F6E" display="ExprOn">
 					<accessible>ExprOn</accessible>
 				</lang>
 			</version>
@@ -6153,8 +5665,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="457870724F6666">
-					<display>ExprOff</display>
+				<lang code="en" ti-ascii="457870724F6666" display="ExprOff">
 					<accessible>ExprOff</accessible>
 				</lang>
 			</version>
@@ -6165,8 +5676,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="436C72416C6C4C69737473">
-					<display>ClrAllLists</display>
+				<lang code="en" ti-ascii="436C72416C6C4C69737473" display="ClrAllLists">
 					<accessible>ClrAllLists</accessible>
 				</lang>
 			</version>
@@ -6177,8 +5687,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="47657443616C6328">
-					<display>GetCalc(</display>
+				<lang code="en" ti-ascii="47657443616C6328" display="GetCalc(">
 					<accessible>GetCalc(</accessible>
 				</lang>
 			</version>
@@ -6193,8 +5702,7 @@
 					<model>TI-83</model>
 					<os-version>1.010</os-version>
 				</until>
-				<lang code="en" ti-ascii="44656C566172">
-					<display>DelVar</display>
+				<lang code="en" ti-ascii="44656C566172" display="DelVar">
 					<accessible>DelVar</accessible>
 				</lang>
 			</version>
@@ -6203,8 +5711,7 @@
 					<model>TI-83</model>
 					<os-version>1.010</os-version>
 				</since>
-				<lang code="en" ti-ascii="44656C56617220">
-					<display>DelVar&#032;</display>
+				<lang code="en" ti-ascii="44656C56617220" display="DelVar&#032;">
 					<accessible>DelVar&#032;</accessible>
 				</lang>
 			</version>
@@ -6215,8 +5722,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="45717505537472696E6728">
-					<display>Equ►String(</display>
+				<lang code="en" ti-ascii="45717505537472696E6728" display="Equ►String(">
 					<accessible>Equ&gt;String(</accessible>
 					<variant>Equ►String(</variant>
 				</lang>
@@ -6228,8 +5734,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="537472696E670545717528">
-					<display>String►Equ(</display>
+				<lang code="en" ti-ascii="537472696E670545717528" display="String►Equ(">
 					<accessible>String&gt;Equ(</accessible>
 					<variant>String►Equ(</variant>
 				</lang>
@@ -6241,8 +5746,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="436C65617220456E7472696573">
-					<display>Clear Entries</display>
+				<lang code="en" ti-ascii="436C65617220456E7472696573" display="Clear Entries">
 					<accessible>Clear Entries</accessible>
 				</lang>
 			</version>
@@ -6253,8 +5757,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="53656C65637428">
-					<display>Select(</display>
+				<lang code="en" ti-ascii="53656C65637428" display="Select(">
 					<accessible>Select(</accessible>
 				</lang>
 			</version>
@@ -6265,8 +5768,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="414E4F564128">
-					<display>ANOVA(</display>
+				<lang code="en" ti-ascii="414E4F564128" display="ANOVA(">
 					<accessible>ANOVA(</accessible>
 				</lang>
 			</version>
@@ -6277,8 +5779,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="4D6F64426F78706C6F74">
-					<display>ModBoxplot</display>
+				<lang code="en" ti-ascii="4D6F64426F78706C6F74" display="ModBoxplot">
 					<accessible>ModBoxplot</accessible>
 				</lang>
 			</version>
@@ -6289,8 +5790,7 @@
 					<model>TI-83</model>
 					<os-version>0.01013</os-version>
 				</since>
-				<lang code="en" ti-ascii="4E6F726D50726F62506C6F74">
-					<display>NormProbPlot</display>
+				<lang code="en" ti-ascii="4E6F726D50726F62506C6F74" display="NormProbPlot">
 					<accessible>NormProbPlot</accessible>
 				</lang>
 			</version>
@@ -6301,8 +5801,7 @@
 					<model>TI-83</model>
 					<os-version>1.010</os-version>
 				</since>
-				<lang code="en" ti-ascii="472D54">
-					<display>G-T</display>
+				<lang code="en" ti-ascii="472D54" display="G-T">
 					<accessible>G-T</accessible>
 				</lang>
 			</version>
@@ -6313,8 +5812,7 @@
 					<model>TI-83</model>
 					<os-version>1.010</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A6F6F6D466974">
-					<display>ZoomFit</display>
+				<lang code="en" ti-ascii="5A6F6F6D466974" display="ZoomFit">
 					<accessible>ZoomFit</accessible>
 				</lang>
 			</version>
@@ -6325,8 +5823,7 @@
 					<model>TI-83</model>
 					<os-version>1.010</os-version>
 				</since>
-				<lang code="en" ti-ascii="446961676E6F737469634F6E">
-					<display>DiagnosticOn</display>
+				<lang code="en" ti-ascii="446961676E6F737469634F6E" display="DiagnosticOn">
 					<accessible>DiagnosticOn</accessible>
 				</lang>
 			</version>
@@ -6337,8 +5834,7 @@
 					<model>TI-83</model>
 					<os-version>1.010</os-version>
 				</since>
-				<lang code="en" ti-ascii="446961676E6F737469634F6666">
-					<display>DiagnosticOff</display>
+				<lang code="en" ti-ascii="446961676E6F737469634F6666" display="DiagnosticOff">
 					<accessible>DiagnosticOff</accessible>
 				</lang>
 			</version>
@@ -6349,8 +5845,7 @@
 					<model>TI-83+</model>
 					<os-version>0.103</os-version>
 				</since>
-				<lang code="en" ti-ascii="4172636869766520">
-					<display>Archive&#032;</display>
+				<lang code="en" ti-ascii="4172636869766520" display="Archive&#032;">
 					<accessible>Archive&#032;</accessible>
 				</lang>
 			</version>
@@ -6361,8 +5856,7 @@
 					<model>TI-83+</model>
 					<os-version>0.103</os-version>
 				</since>
-				<lang code="en" ti-ascii="556E4172636869766520">
-					<display>UnArchive&#032;</display>
+				<lang code="en" ti-ascii="556E4172636869766520" display="UnArchive&#032;">
 					<accessible>UnArchive&#032;</accessible>
 				</lang>
 			</version>
@@ -6373,8 +5867,7 @@
 					<model>TI-83+</model>
 					<os-version>0.103</os-version>
 				</since>
-				<lang code="en" ti-ascii="41736D28">
-					<display>Asm(</display>
+				<lang code="en" ti-ascii="41736D28" display="Asm(">
 					<accessible>Asm(</accessible>
 				</lang>
 			</version>
@@ -6385,8 +5878,7 @@
 					<model>TI-83+</model>
 					<os-version>0.103</os-version>
 				</since>
-				<lang code="en" ti-ascii="41736D436F6D7028">
-					<display>AsmComp(</display>
+				<lang code="en" ti-ascii="41736D436F6D7028" display="AsmComp(">
 					<accessible>AsmComp(</accessible>
 				</lang>
 			</version>
@@ -6397,8 +5889,7 @@
 					<model>TI-83+</model>
 					<os-version>0.103</os-version>
 				</since>
-				<lang code="en" ti-ascii="41736D5072676D">
-					<display>AsmPrgm</display>
+				<lang code="en" ti-ascii="41736D5072676D" display="AsmPrgm">
 					<accessible>AsmPrgm</accessible>
 				</lang>
 			</version>
@@ -6409,8 +5900,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="8A">
-					<display>Á</display>
+				<lang code="en" ti-ascii="8A" display="Á">
 					<accessible>Á</accessible>
 				</lang>
 			</version>
@@ -6421,8 +5911,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="8B">
-					<display>À</display>
+				<lang code="en" ti-ascii="8B" display="À">
 					<accessible>À</accessible>
 				</lang>
 			</version>
@@ -6433,8 +5922,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="8C">
-					<display>Â</display>
+				<lang code="en" ti-ascii="8C" display="Â">
 					<accessible>Â</accessible>
 				</lang>
 			</version>
@@ -6445,8 +5933,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="8D">
-					<display>Ä</display>
+				<lang code="en" ti-ascii="8D" display="Ä">
 					<accessible>Ä</accessible>
 				</lang>
 			</version>
@@ -6457,8 +5944,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="8E">
-					<display>á</display>
+				<lang code="en" ti-ascii="8E" display="á">
 					<accessible>á</accessible>
 				</lang>
 			</version>
@@ -6469,8 +5955,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="8F">
-					<display>à</display>
+				<lang code="en" ti-ascii="8F" display="à">
 					<accessible>à</accessible>
 				</lang>
 			</version>
@@ -6481,8 +5966,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="90">
-					<display>â</display>
+				<lang code="en" ti-ascii="90" display="â">
 					<accessible>â</accessible>
 				</lang>
 			</version>
@@ -6493,8 +5977,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="91">
-					<display>ä</display>
+				<lang code="en" ti-ascii="91" display="ä">
 					<accessible>ä</accessible>
 				</lang>
 			</version>
@@ -6505,8 +5988,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="92">
-					<display>É</display>
+				<lang code="en" ti-ascii="92" display="É">
 					<accessible>É</accessible>
 				</lang>
 			</version>
@@ -6517,8 +5999,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="93">
-					<display>È</display>
+				<lang code="en" ti-ascii="93" display="È">
 					<accessible>È</accessible>
 				</lang>
 			</version>
@@ -6529,8 +6010,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="94">
-					<display>Ê</display>
+				<lang code="en" ti-ascii="94" display="Ê">
 					<accessible>Ê</accessible>
 				</lang>
 			</version>
@@ -6541,8 +6021,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="95">
-					<display>Ë</display>
+				<lang code="en" ti-ascii="95" display="Ë">
 					<accessible>Ë</accessible>
 				</lang>
 			</version>
@@ -6553,8 +6032,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="96">
-					<display>é</display>
+				<lang code="en" ti-ascii="96" display="é">
 					<accessible>é</accessible>
 				</lang>
 			</version>
@@ -6565,8 +6043,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="97">
-					<display>è</display>
+				<lang code="en" ti-ascii="97" display="è">
 					<accessible>è</accessible>
 				</lang>
 			</version>
@@ -6577,8 +6054,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="98">
-					<display>ê</display>
+				<lang code="en" ti-ascii="98" display="ê">
 					<accessible>ê</accessible>
 				</lang>
 			</version>
@@ -6589,8 +6065,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="99">
-					<display>ë</display>
+				<lang code="en" ti-ascii="99" display="ë">
 					<accessible>ë</accessible>
 				</lang>
 			</version>
@@ -6601,8 +6076,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="9B">
-					<display>Ì</display>
+				<lang code="en" ti-ascii="9B" display="Ì">
 					<accessible>Ì</accessible>
 				</lang>
 			</version>
@@ -6613,8 +6087,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="9C">
-					<display>Î</display>
+				<lang code="en" ti-ascii="9C" display="Î">
 					<accessible>Î</accessible>
 				</lang>
 			</version>
@@ -6625,8 +6098,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="9D">
-					<display>Ï</display>
+				<lang code="en" ti-ascii="9D" display="Ï">
 					<accessible>Ï</accessible>
 				</lang>
 			</version>
@@ -6637,8 +6109,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="9E">
-					<display>í</display>
+				<lang code="en" ti-ascii="9E" display="í">
 					<accessible>í</accessible>
 				</lang>
 			</version>
@@ -6649,8 +6120,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="9F">
-					<display>ì</display>
+				<lang code="en" ti-ascii="9F" display="ì">
 					<accessible>ì</accessible>
 				</lang>
 			</version>
@@ -6661,8 +6131,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="A0">
-					<display>î</display>
+				<lang code="en" ti-ascii="A0" display="î">
 					<accessible>î</accessible>
 				</lang>
 			</version>
@@ -6673,8 +6142,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="A1">
-					<display>ï</display>
+				<lang code="en" ti-ascii="A1" display="ï">
 					<accessible>ï</accessible>
 				</lang>
 			</version>
@@ -6685,8 +6153,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="A2">
-					<display>Ó</display>
+				<lang code="en" ti-ascii="A2" display="Ó">
 					<accessible>Ó</accessible>
 				</lang>
 			</version>
@@ -6697,8 +6164,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="A3">
-					<display>Ò</display>
+				<lang code="en" ti-ascii="A3" display="Ò">
 					<accessible>Ò</accessible>
 				</lang>
 			</version>
@@ -6709,8 +6175,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="A4">
-					<display>Ô</display>
+				<lang code="en" ti-ascii="A4" display="Ô">
 					<accessible>Ô</accessible>
 				</lang>
 			</version>
@@ -6721,8 +6186,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="A5">
-					<display>Ö</display>
+				<lang code="en" ti-ascii="A5" display="Ö">
 					<accessible>Ö</accessible>
 				</lang>
 			</version>
@@ -6733,8 +6197,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="A6">
-					<display>ó</display>
+				<lang code="en" ti-ascii="A6" display="ó">
 					<accessible>ó</accessible>
 				</lang>
 			</version>
@@ -6745,8 +6208,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="A7">
-					<display>ò</display>
+				<lang code="en" ti-ascii="A7" display="ò">
 					<accessible>ò</accessible>
 				</lang>
 			</version>
@@ -6757,8 +6219,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="A8">
-					<display>ô</display>
+				<lang code="en" ti-ascii="A8" display="ô">
 					<accessible>ô</accessible>
 				</lang>
 			</version>
@@ -6769,8 +6230,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="A9">
-					<display>ö</display>
+				<lang code="en" ti-ascii="A9" display="ö">
 					<accessible>ö</accessible>
 				</lang>
 			</version>
@@ -6781,8 +6241,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="AA">
-					<display>Ú</display>
+				<lang code="en" ti-ascii="AA" display="Ú">
 					<accessible>Ú</accessible>
 				</lang>
 			</version>
@@ -6793,8 +6252,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="AB">
-					<display>Ù</display>
+				<lang code="en" ti-ascii="AB" display="Ù">
 					<accessible>Ù</accessible>
 				</lang>
 			</version>
@@ -6805,8 +6263,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="AC">
-					<display>Û</display>
+				<lang code="en" ti-ascii="AC" display="Û">
 					<accessible>Û</accessible>
 				</lang>
 			</version>
@@ -6817,8 +6274,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="AD">
-					<display>Ü</display>
+				<lang code="en" ti-ascii="AD" display="Ü">
 					<accessible>Ü</accessible>
 				</lang>
 			</version>
@@ -6829,8 +6285,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="AE">
-					<display>ú</display>
+				<lang code="en" ti-ascii="AE" display="ú">
 					<accessible>ú</accessible>
 				</lang>
 			</version>
@@ -6841,8 +6296,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="AF">
-					<display>ù</display>
+				<lang code="en" ti-ascii="AF" display="ù">
 					<accessible>ù</accessible>
 				</lang>
 			</version>
@@ -6853,8 +6307,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="B0">
-					<display>û</display>
+				<lang code="en" ti-ascii="B0" display="û">
 					<accessible>û</accessible>
 				</lang>
 			</version>
@@ -6865,8 +6318,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="B1">
-					<display>ü</display>
+				<lang code="en" ti-ascii="B1" display="ü">
 					<accessible>ü</accessible>
 				</lang>
 			</version>
@@ -6877,8 +6329,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="B2">
-					<display>Ç</display>
+				<lang code="en" ti-ascii="B2" display="Ç">
 					<accessible>Ç</accessible>
 				</lang>
 			</version>
@@ -6889,8 +6340,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="B3">
-					<display>ç</display>
+				<lang code="en" ti-ascii="B3" display="ç">
 					<accessible>ç</accessible>
 				</lang>
 			</version>
@@ -6901,8 +6351,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="B4">
-					<display>Ñ</display>
+				<lang code="en" ti-ascii="B4" display="Ñ">
 					<accessible>Ñ</accessible>
 				</lang>
 			</version>
@@ -6913,8 +6362,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="B5">
-					<display>ñ</display>
+				<lang code="en" ti-ascii="B5" display="ñ">
 					<accessible>ñ</accessible>
 				</lang>
 			</version>
@@ -6925,8 +6373,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="B6">
-					<display>´</display>
+				<lang code="en" ti-ascii="B6" display="´">
 					<accessible>|&apos;</accessible>
 					<variant>´</variant>
 					<variant>^^&apos;</variant>
@@ -6939,8 +6386,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="B7">
-					<display>`</display>
+				<lang code="en" ti-ascii="B7" display="`">
 					<accessible>|`</accessible>
 					<variant>^^`</variant>
 				</lang>
@@ -6952,8 +6398,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="B8">
-					<display>¨</display>
+				<lang code="en" ti-ascii="B8" display="¨">
 					<accessible>|:</accessible>
 					<variant>¨</variant>
 					<variant>^^:</variant>
@@ -6966,8 +6411,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="B9">
-					<display>¿</display>
+				<lang code="en" ti-ascii="B9" display="¿">
 					<accessible>|?</accessible>
 					<variant>¿</variant>
 				</lang>
@@ -6979,8 +6423,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="BA">
-					<display>¡</display>
+				<lang code="en" ti-ascii="BA" display="¡">
 					<accessible>|!</accessible>
 					<variant>¡</variant>
 				</lang>
@@ -6992,8 +6435,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="BB">
-					<display>α</display>
+				<lang code="en" ti-ascii="BB" display="α">
 					<accessible>alpha</accessible>
 					<variant>α</variant>
 				</lang>
@@ -7005,8 +6447,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="BC">
-					<display>β</display>
+				<lang code="en" ti-ascii="BC" display="β">
 					<accessible>beta</accessible>
 					<variant>β</variant>
 				</lang>
@@ -7018,8 +6459,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="BD">
-					<display>γ</display>
+				<lang code="en" ti-ascii="BD" display="γ">
 					<accessible>gamma</accessible>
 					<variant>γ</variant>
 				</lang>
@@ -7031,8 +6471,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="BE">
-					<display>Δ</display>
+				<lang code="en" ti-ascii="BE" display="Δ">
 					<accessible>Delta</accessible>
 					<variant>Δ</variant>
 				</lang>
@@ -7044,8 +6483,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="BF">
-					<display>δ</display>
+				<lang code="en" ti-ascii="BF" display="δ">
 					<accessible>delta</accessible>
 					<variant>δ</variant>
 				</lang>
@@ -7057,8 +6495,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="C0">
-					<display>ε</display>
+				<lang code="en" ti-ascii="C0" display="ε">
 					<accessible>epsilon</accessible>
 					<variant>ε</variant>
 				</lang>
@@ -7070,8 +6507,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="C2">
-					<display>λ</display>
+				<lang code="en" ti-ascii="C2" display="λ">
 					<accessible>lambda</accessible>
 					<variant>λ</variant>
 				</lang>
@@ -7083,8 +6519,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="C3">
-					<display>μ</display>
+				<lang code="en" ti-ascii="C3" display="μ">
 					<accessible>mu</accessible>
 					<variant>μ</variant>
 				</lang>
@@ -7096,8 +6531,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="C4">
-					<display>π</display>
+				<lang code="en" ti-ascii="C4" display="π">
 					<accessible>greek_pi</accessible>
 					<variant>|π</variant>
 				</lang>
@@ -7109,8 +6543,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="C5">
-					<display>ρ</display>
+				<lang code="en" ti-ascii="C5" display="ρ">
 					<accessible>rho</accessible>
 					<variant>ρ</variant>
 				</lang>
@@ -7122,8 +6555,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="C6">
-					<display>Σ</display>
+				<lang code="en" ti-ascii="C6" display="Σ">
 					<accessible>Sigma</accessible>
 					<variant>Σ</variant>
 				</lang>
@@ -7135,8 +6567,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="C9">
-					<display>Φ</display>
+				<lang code="en" ti-ascii="C9" display="Φ">
 					<accessible>Phi</accessible>
 					<variant>Φ</variant>
 				</lang>
@@ -7148,8 +6579,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="CA">
-					<display>Ω</display>
+				<lang code="en" ti-ascii="CA" display="Ω">
 					<accessible>Omega</accessible>
 					<variant>Ω</variant>
 				</lang>
@@ -7161,8 +6591,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="D8">
-					<display>p̂</display>
+				<lang code="en" ti-ascii="D8" display="p̂">
 					<accessible>phat</accessible>
 					<variant>ṗ</variant>
 				</lang>
@@ -7174,8 +6603,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="D9">
-					<display>χ</display>
+				<lang code="en" ti-ascii="D9" display="χ">
 					<accessible>chi</accessible>
 					<variant>χ</variant>
 				</lang>
@@ -7187,8 +6615,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="DA">
-					<display>𝙵</display>
+				<lang code="en" ti-ascii="DA" display="𝙵">
 					<accessible>|F</accessible>
 					<variant>𝐅</variant>
 					<variant>|𝐅</variant>
@@ -7201,8 +6628,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="61">
-					<display>a</display>
+				<lang code="en" ti-ascii="61" display="a">
 					<accessible>a</accessible>
 				</lang>
 			</version>
@@ -7213,8 +6639,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="62">
-					<display>b</display>
+				<lang code="en" ti-ascii="62" display="b">
 					<accessible>b</accessible>
 				</lang>
 			</version>
@@ -7225,8 +6650,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="63">
-					<display>c</display>
+				<lang code="en" ti-ascii="63" display="c">
 					<accessible>c</accessible>
 				</lang>
 			</version>
@@ -7237,8 +6661,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="64">
-					<display>d</display>
+				<lang code="en" ti-ascii="64" display="d">
 					<accessible>d</accessible>
 				</lang>
 			</version>
@@ -7249,8 +6672,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="65">
-					<display>e</display>
+				<lang code="en" ti-ascii="65" display="e">
 					<accessible>e</accessible>
 				</lang>
 			</version>
@@ -7261,8 +6683,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="66">
-					<display>f</display>
+				<lang code="en" ti-ascii="66" display="f">
 					<accessible>f</accessible>
 				</lang>
 			</version>
@@ -7273,8 +6694,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="67">
-					<display>g</display>
+				<lang code="en" ti-ascii="67" display="g">
 					<accessible>g</accessible>
 				</lang>
 			</version>
@@ -7285,8 +6705,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="68">
-					<display>h</display>
+				<lang code="en" ti-ascii="68" display="h">
 					<accessible>h</accessible>
 				</lang>
 			</version>
@@ -7297,8 +6716,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="69">
-					<display>i</display>
+				<lang code="en" ti-ascii="69" display="i">
 					<accessible>i</accessible>
 				</lang>
 			</version>
@@ -7309,8 +6727,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="6A">
-					<display>j</display>
+				<lang code="en" ti-ascii="6A" display="j">
 					<accessible>j</accessible>
 				</lang>
 			</version>
@@ -7321,8 +6738,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="6B">
-					<display>k</display>
+				<lang code="en" ti-ascii="6B" display="k">
 					<accessible>k</accessible>
 				</lang>
 			</version>
@@ -7333,8 +6749,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="6C">
-					<display>l</display>
+				<lang code="en" ti-ascii="6C" display="l">
 					<accessible>l</accessible>
 				</lang>
 			</version>
@@ -7345,8 +6760,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="6D">
-					<display>m</display>
+				<lang code="en" ti-ascii="6D" display="m">
 					<accessible>m</accessible>
 				</lang>
 			</version>
@@ -7357,8 +6771,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="6E">
-					<display>n</display>
+				<lang code="en" ti-ascii="6E" display="n">
 					<accessible>n</accessible>
 				</lang>
 			</version>
@@ -7369,8 +6782,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="6F">
-					<display>o</display>
+				<lang code="en" ti-ascii="6F" display="o">
 					<accessible>o</accessible>
 				</lang>
 			</version>
@@ -7381,8 +6793,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="70">
-					<display>p</display>
+				<lang code="en" ti-ascii="70" display="p">
 					<accessible>p</accessible>
 				</lang>
 			</version>
@@ -7393,8 +6804,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="71">
-					<display>q</display>
+				<lang code="en" ti-ascii="71" display="q">
 					<accessible>q</accessible>
 				</lang>
 			</version>
@@ -7405,8 +6815,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="72">
-					<display>r</display>
+				<lang code="en" ti-ascii="72" display="r">
 					<accessible>r</accessible>
 				</lang>
 			</version>
@@ -7417,8 +6826,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="73">
-					<display>s</display>
+				<lang code="en" ti-ascii="73" display="s">
 					<accessible>s</accessible>
 				</lang>
 			</version>
@@ -7429,8 +6837,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="74">
-					<display>t</display>
+				<lang code="en" ti-ascii="74" display="t">
 					<accessible>t</accessible>
 				</lang>
 			</version>
@@ -7441,8 +6848,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="75">
-					<display>u</display>
+				<lang code="en" ti-ascii="75" display="u">
 					<accessible>u</accessible>
 				</lang>
 			</version>
@@ -7453,8 +6859,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="76">
-					<display>v</display>
+				<lang code="en" ti-ascii="76" display="v">
 					<accessible>v</accessible>
 				</lang>
 			</version>
@@ -7465,8 +6870,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="77">
-					<display>w</display>
+				<lang code="en" ti-ascii="77" display="w">
 					<accessible>w</accessible>
 				</lang>
 			</version>
@@ -7477,8 +6881,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="78">
-					<display>x</display>
+				<lang code="en" ti-ascii="78" display="x">
 					<accessible>x</accessible>
 				</lang>
 			</version>
@@ -7489,8 +6892,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="79">
-					<display>y</display>
+				<lang code="en" ti-ascii="79" display="y">
 					<accessible>y</accessible>
 				</lang>
 			</version>
@@ -7501,8 +6903,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="7A">
-					<display>z</display>
+				<lang code="en" ti-ascii="7A" display="z">
 					<accessible>z</accessible>
 				</lang>
 			</version>
@@ -7513,8 +6914,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="C7">
-					<display>σ</display>
+				<lang code="en" ti-ascii="C7" display="σ">
 					<accessible>sigma</accessible>
 					<variant>σ</variant>
 				</lang>
@@ -7526,8 +6926,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="C8">
-					<display>τ</display>
+				<lang code="en" ti-ascii="C8" display="τ">
 					<accessible>tau</accessible>
 					<variant>τ</variant>
 				</lang>
@@ -7539,8 +6938,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="9A">
-					<display>Í</display>
+				<lang code="en" ti-ascii="9A" display="Í">
 					<accessible>Í</accessible>
 				</lang>
 			</version>
@@ -7551,8 +6949,7 @@
 					<model>TI-83+</model>
 					<os-version>1.03</os-version>
 				</since>
-				<lang code="en" ti-ascii="47617262616765436F6C6C656374">
-					<display>GarbageCollect</display>
+				<lang code="en" ti-ascii="47617262616765436F6C6C656374" display="GarbageCollect">
 					<accessible>GarbageCollect</accessible>
 				</lang>
 			</version>
@@ -7563,8 +6960,7 @@
 					<model>TI-83+</model>
 					<os-version>1.15</os-version>
 				</since>
-				<lang code="en" ti-ascii="7E">
-					<display>~</display>
+				<lang code="en" ti-ascii="7E" display="~">
 					<accessible>|~</accessible>
 				</lang>
 			</version>
@@ -7575,8 +6971,7 @@
 					<model>TI-83+</model>
 					<os-version>1.15</os-version>
 				</since>
-				<lang code="en" ti-ascii="40">
-					<display>@</display>
+				<lang code="en" ti-ascii="40" display="@">
 					<accessible>@</accessible>
 				</lang>
 			</version>
@@ -7587,8 +6982,7 @@
 					<model>TI-83+</model>
 					<os-version>1.15</os-version>
 				</since>
-				<lang code="en" ti-ascii="23">
-					<display>#</display>
+				<lang code="en" ti-ascii="23" display="#">
 					<accessible>#</accessible>
 				</lang>
 			</version>
@@ -7599,8 +6993,7 @@
 					<model>TI-83+</model>
 					<os-version>1.15</os-version>
 				</since>
-				<lang code="en" ti-ascii="F2">
-					<display>$</display>
+				<lang code="en" ti-ascii="F2" display="$">
 					<accessible>$</accessible>
 				</lang>
 			</version>
@@ -7611,8 +7004,7 @@
 					<model>TI-83+</model>
 					<os-version>1.15</os-version>
 				</since>
-				<lang code="en" ti-ascii="26">
-					<display>&amp;</display>
+				<lang code="en" ti-ascii="26" display="&amp;">
 					<accessible>&amp;</accessible>
 				</lang>
 			</version>
@@ -7623,8 +7015,7 @@
 					<model>TI-83+</model>
 					<os-version>1.15</os-version>
 				</since>
-				<lang code="en" ti-ascii="B7">
-					<display>`</display>
+				<lang code="en" ti-ascii="B7" display="`">
 					<accessible>`</accessible>
 				</lang>
 			</version>
@@ -7635,8 +7026,7 @@
 					<model>TI-83+</model>
 					<os-version>1.15</os-version>
 				</since>
-				<lang code="en" ti-ascii="3B">
-					<display>;</display>
+				<lang code="en" ti-ascii="3B" display=";">
 					<accessible>;</accessible>
 				</lang>
 			</version>
@@ -7647,8 +7037,7 @@
 					<model>TI-83+</model>
 					<os-version>1.15</os-version>
 				</since>
-				<lang code="en" ti-ascii="5C">
-					<display>\</display>
+				<lang code="en" ti-ascii="5C" display="\">
 					<accessible>\</accessible>
 				</lang>
 			</version>
@@ -7659,8 +7048,7 @@
 					<model>TI-83+</model>
 					<os-version>1.15</os-version>
 				</since>
-				<lang code="en" ti-ascii="7C">
-					<display>|</display>
+				<lang code="en" ti-ascii="7C" display="|">
 					<accessible>|</accessible>
 				</lang>
 			</version>
@@ -7671,8 +7059,7 @@
 					<model>TI-83+</model>
 					<os-version>1.15</os-version>
 				</since>
-				<lang code="en" ti-ascii="5F">
-					<display>_</display>
+				<lang code="en" ti-ascii="5F" display="_">
 					<accessible>_</accessible>
 				</lang>
 			</version>
@@ -7683,8 +7070,7 @@
 					<model>TI-83+</model>
 					<os-version>1.15</os-version>
 				</since>
-				<lang code="en" ti-ascii="25">
-					<display>%</display>
+				<lang code="en" ti-ascii="25" display="%">
 					<accessible>%</accessible>
 				</lang>
 			</version>
@@ -7695,8 +7081,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="CE">
-					<display>…</display>
+				<lang code="en" ti-ascii="CE" display="…">
 					<accessible>...</accessible>
 					<variant>…</variant>
 				</lang>
@@ -7708,8 +7093,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="13">
-					<display>∠</display>
+				<lang code="en" ti-ascii="13" display="∠">
 					<accessible>|&lt;</accessible>
 					<variant>∠</variant>
 				</lang>
@@ -7721,8 +7105,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="F4">
-					<display>ß</display>
+				<lang code="en" ti-ascii="F4" display="ß">
 					<accessible>sharps</accessible>
 					<variant>ß</variant>
 				</lang>
@@ -7734,8 +7117,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="CD">
-					<display>ˣ</display>
+				<lang code="en" ti-ascii="CD" display="ˣ">
 					<accessible>^^x</accessible>
 					<variant>ˣ</variant>
 				</lang>
@@ -7747,8 +7129,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="0D">
-					<display>ᴛ</display>
+				<lang code="en" ti-ascii="0D" display="ᴛ">
 					<accessible>smallT</accessible>
 					<variant>ᴛ</variant>
 				</lang>
@@ -7760,8 +7141,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="80">
-					<display>₀</display>
+				<lang code="en" ti-ascii="80" display="₀">
 					<accessible>small0</accessible>
 					<variant>₀</variant>
 				</lang>
@@ -7773,8 +7153,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="81">
-					<display>₁</display>
+				<lang code="en" ti-ascii="81" display="₁">
 					<accessible>small1</accessible>
 					<variant>₁</variant>
 				</lang>
@@ -7786,8 +7165,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="82">
-					<display>₂</display>
+				<lang code="en" ti-ascii="82" display="₂">
 					<accessible>small2</accessible>
 					<variant>₂</variant>
 				</lang>
@@ -7799,8 +7177,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="83">
-					<display>₃</display>
+				<lang code="en" ti-ascii="83" display="₃">
 					<accessible>small3</accessible>
 					<variant>₃</variant>
 				</lang>
@@ -7812,8 +7189,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="84">
-					<display>₄</display>
+				<lang code="en" ti-ascii="84" display="₄">
 					<accessible>small4</accessible>
 					<variant>₄</variant>
 				</lang>
@@ -7825,8 +7201,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="85">
-					<display>₅</display>
+				<lang code="en" ti-ascii="85" display="₅">
 					<accessible>small5</accessible>
 					<variant>₅</variant>
 				</lang>
@@ -7838,8 +7213,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="86">
-					<display>₆</display>
+				<lang code="en" ti-ascii="86" display="₆">
 					<accessible>small6</accessible>
 					<variant>₆</variant>
 				</lang>
@@ -7851,8 +7225,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="87">
-					<display>₇</display>
+				<lang code="en" ti-ascii="87" display="₇">
 					<accessible>small7</accessible>
 					<variant>₇</variant>
 				</lang>
@@ -7864,8 +7237,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="88">
-					<display>₈</display>
+				<lang code="en" ti-ascii="88" display="₈">
 					<accessible>small8</accessible>
 					<variant>₈</variant>
 				</lang>
@@ -7877,8 +7249,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="89">
-					<display>₉</display>
+				<lang code="en" ti-ascii="89" display="₉">
 					<accessible>small9</accessible>
 					<variant>₉</variant>
 				</lang>
@@ -7890,8 +7261,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="1D">
-					<display>₁₀</display>
+				<lang code="en" ti-ascii="1D" display="₁₀">
 					<accessible>small10</accessible>
 					<variant>₁₀</variant>
 				</lang>
@@ -7903,8 +7273,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="CF">
-					<display>◄</display>
+				<lang code="en" ti-ascii="CF" display="◄">
 					<accessible>&lt;|</accessible>
 					<variant>◄</variant>
 				</lang>
@@ -7916,8 +7285,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="05">
-					<display>►</display>
+				<lang code="en" ti-ascii="05" display="►">
 					<accessible>|&gt;</accessible>
 					<variant>►</variant>
 				</lang>
@@ -7929,8 +7297,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="1E">
-					<display>↑</display>
+				<lang code="en" ti-ascii="1E" display="↑">
 					<accessible>uparrow</accessible>
 					<variant>↑</variant>
 				</lang>
@@ -7942,8 +7309,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="1F">
-					<display>↓</display>
+				<lang code="en" ti-ascii="1F" display="↓">
 					<accessible>downarrow</accessible>
 					<variant>↓</variant>
 				</lang>
@@ -7955,8 +7321,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="09">
-					<display>×</display>
+				<lang code="en" ti-ascii="09" display="×">
 					<accessible>xmark</accessible>
 					<variant>×</variant>
 				</lang>
@@ -7968,8 +7333,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="08">
-					<display>∫</display>
+				<lang code="en" ti-ascii="08" display="∫">
 					<accessible>integral</accessible>
 					<variant>∫</variant>
 				</lang>
@@ -7981,8 +7345,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="F3">
-					<display>🡁</display>
+				<lang code="en" ti-ascii="F3" display="🡁">
 					<accessible>bolduparrow</accessible>
 					<variant>🡁</variant>
 					<variant>🡅</variant>
@@ -7995,8 +7358,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="07">
-					<display>🠿</display>
+				<lang code="en" ti-ascii="07" display="🠿">
 					<accessible>bolddownarrow</accessible>
 					<variant>🠿</variant>
 					<variant>🡇</variant>
@@ -8009,8 +7371,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="10">
-					<display>√</display>
+				<lang code="en" ti-ascii="10" display="√">
 					<accessible>squareroot</accessible>
 				</lang>
 			</version>
@@ -8021,8 +7382,7 @@
 					<model>TI-83+</model>
 					<os-version>1.16</os-version>
 				</since>
-				<lang code="en" ti-ascii="7F">
-					<display>⌸</display>
+				<lang code="en" ti-ascii="7F" display="⌸">
 					<accessible>invertedequal</accessible>
 					<variant>⌸</variant>
 				</lang>
@@ -8039,8 +7399,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="10">
-				<display>√</display>
+			<lang code="en" ti-ascii="10" display="√">
 				<accessible>sqrt</accessible>
 				<variant>√</variant>
 			</lang>
@@ -8050,8 +7409,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="1028">
-				<display>√(</display>
+			<lang code="en" ti-ascii="1028" display="√(">
 				<accessible>sqrt(</accessible>
 				<variant>√(</variant>
 			</lang>
@@ -8067,8 +7425,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="0E10">
-				<display>³√</display>
+			<lang code="en" ti-ascii="0E10" display="³√">
 				<accessible>cuberoot</accessible>
 				<variant>³√</variant>
 			</lang>
@@ -8078,8 +7435,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="0E1028">
-				<display>³√(</display>
+			<lang code="en" ti-ascii="0E1028" display="³√(">
 				<accessible>cuberoot(</accessible>
 				<variant>³√(</variant>
 			</lang>
@@ -8095,8 +7451,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="6C6E20">
-				<display>ln&#032;</display>
+			<lang code="en" ti-ascii="6C6E20" display="ln&#032;">
 				<accessible>ln&#032;</accessible>
 			</lang>
 		</version>
@@ -8105,8 +7460,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="6C6E28">
-				<display>ln(</display>
+			<lang code="en" ti-ascii="6C6E28" display="ln(">
 				<accessible>ln(</accessible>
 			</lang>
 		</version>
@@ -8121,8 +7475,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="DB5E">
-				<display>𝑒^</display>
+			<lang code="en" ti-ascii="DB5E" display="𝑒^">
 				<accessible>e^^</accessible>
 				<variant>𝑒^</variant>
 			</lang>
@@ -8132,8 +7485,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="DB5E28">
-				<display>𝑒^(</display>
+			<lang code="en" ti-ascii="DB5E28" display="𝑒^(">
 				<accessible>e^^(</accessible>
 				<variant>𝑒^(</variant>
 			</lang>
@@ -8149,8 +7501,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="6C6F67">
-				<display>log&#032;</display>
+			<lang code="en" ti-ascii="6C6F67" display="log&#032;">
 				<accessible>log&#032;</accessible>
 			</lang>
 		</version>
@@ -8159,8 +7510,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="6C6F6728">
-				<display>log(</display>
+			<lang code="en" ti-ascii="6C6F6728" display="log(">
 				<accessible>log(</accessible>
 			</lang>
 		</version>
@@ -8175,8 +7525,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="1D5E">
-				<display>₁₀^</display>
+			<lang code="en" ti-ascii="1D5E" display="₁₀^">
 				<accessible>10^^</accessible>
 				<variant>₁₀^</variant>
 			</lang>
@@ -8186,8 +7535,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="1D5E28">
-				<display>₁₀^(</display>
+			<lang code="en" ti-ascii="1D5E28" display="₁₀^(">
 				<accessible>10^^(</accessible>
 				<variant>₁₀^(</variant>
 			</lang>
@@ -8203,8 +7551,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="73696E20">
-				<display>sin&#032;</display>
+			<lang code="en" ti-ascii="73696E20" display="sin&#032;">
 				<accessible>sin&#032;</accessible>
 			</lang>
 		</version>
@@ -8213,8 +7560,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="73696E28">
-				<display>sin(</display>
+			<lang code="en" ti-ascii="73696E28" display="sin(">
 				<accessible>sin(</accessible>
 			</lang>
 		</version>
@@ -8229,8 +7575,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="73696E1120">
-				<display>sin⁻¹&#032;</display>
+			<lang code="en" ti-ascii="73696E1120" display="sin⁻¹&#032;">
 				<accessible>sin^-1&#032;</accessible>
 				<variant>sin⁻¹&#032;</variant>
 				<variant>arcsin&#032;</variant>
@@ -8242,8 +7587,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="73696E1128">
-				<display>sin⁻¹(</display>
+			<lang code="en" ti-ascii="73696E1128" display="sin⁻¹(">
 				<accessible>sin^-1(</accessible>
 				<variant>sin⁻¹(</variant>
 				<variant>arcsin(</variant>
@@ -8261,8 +7605,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="636F7320">
-				<display>cos&#032;</display>
+			<lang code="en" ti-ascii="636F7320" display="cos&#032;">
 				<accessible>cos&#032;</accessible>
 			</lang>
 		</version>
@@ -8271,8 +7614,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="636F7328">
-				<display>cos(</display>
+			<lang code="en" ti-ascii="636F7328" display="cos(">
 				<accessible>cos(</accessible>
 			</lang>
 		</version>
@@ -8287,8 +7629,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="636F731120">
-				<display>cos⁻¹&#032;</display>
+			<lang code="en" ti-ascii="636F731120" display="cos⁻¹&#032;">
 				<accessible>cos^-1&#032;</accessible>
 				<variant>cos⁻¹&#032;</variant>
 				<variant>arccos&#032;</variant>
@@ -8300,8 +7641,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="636F731128">
-				<display>cos⁻¹(</display>
+			<lang code="en" ti-ascii="636F731128" display="cos⁻¹(">
 				<accessible>cos^-1(</accessible>
 				<variant>cos⁻¹(</variant>
 				<variant>arccos(</variant>
@@ -8319,8 +7659,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="74616E20">
-				<display>tan&#032;</display>
+			<lang code="en" ti-ascii="74616E20" display="tan&#032;">
 				<accessible>tan&#032;</accessible>
 			</lang>
 		</version>
@@ -8329,8 +7668,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="74616E28">
-				<display>tan(</display>
+			<lang code="en" ti-ascii="74616E28" display="tan(">
 				<accessible>tan(</accessible>
 			</lang>
 		</version>
@@ -8345,8 +7683,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="74616E1120">
-				<display>tan⁻¹&#032;</display>
+			<lang code="en" ti-ascii="74616E1120" display="tan⁻¹&#032;">
 				<accessible>tan^-1&#032;</accessible>
 				<variant>tan⁻¹&#032;</variant>
 				<variant>arctan&#032;</variant>
@@ -8358,8 +7695,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="74616E1128">
-				<display>tan⁻¹(</display>
+			<lang code="en" ti-ascii="74616E1128" display="tan⁻¹(">
 				<accessible>tan^-1(</accessible>
 				<variant>tan⁻¹(</variant>
 				<variant>arctan(</variant>
@@ -8377,8 +7713,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="73696E6820">
-				<display>sinh&#032;</display>
+			<lang code="en" ti-ascii="73696E6820" display="sinh&#032;">
 				<accessible>sinh&#032;</accessible>
 			</lang>
 		</version>
@@ -8387,8 +7722,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="73696E6828">
-				<display>sinh(</display>
+			<lang code="en" ti-ascii="73696E6828" display="sinh(">
 				<accessible>sinh(</accessible>
 			</lang>
 		</version>
@@ -8403,8 +7737,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="73696E681120">
-				<display>sinh⁻¹&#032;</display>
+			<lang code="en" ti-ascii="73696E681120" display="sinh⁻¹&#032;">
 				<accessible>sinh^-1&#032;</accessible>
 				<variant>sinh⁻¹&#032;</variant>
 				<variant>arcsinh&#032;</variant>
@@ -8416,8 +7749,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="73696E681128">
-				<display>sinh⁻¹(</display>
+			<lang code="en" ti-ascii="73696E681128" display="sinh⁻¹(">
 				<accessible>sinh^-1(</accessible>
 				<variant>sinh⁻¹(</variant>
 				<variant>arcsinh(</variant>
@@ -8435,8 +7767,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="636F736820">
-				<display>cosh&#032;</display>
+			<lang code="en" ti-ascii="636F736820" display="cosh&#032;">
 				<accessible>cosh&#032;</accessible>
 			</lang>
 		</version>
@@ -8445,8 +7776,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="636F736828">
-				<display>cosh(</display>
+			<lang code="en" ti-ascii="636F736828" display="cosh(">
 				<accessible>cosh(</accessible>
 			</lang>
 		</version>
@@ -8461,8 +7791,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="636F73681120">
-				<display>cosh⁻¹&#032;</display>
+			<lang code="en" ti-ascii="636F73681120" display="cosh⁻¹&#032;">
 				<accessible>cosh^-1&#032;</accessible>
 				<variant>cosh⁻¹&#032;</variant>
 				<variant>arccosh&#032;</variant>
@@ -8474,8 +7803,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="636F73681128">
-				<display>cosh⁻¹(</display>
+			<lang code="en" ti-ascii="636F73681128" display="cosh⁻¹(">
 				<accessible>cosh^-1(</accessible>
 				<variant>cosh⁻¹(</variant>
 				<variant>arccosh(</variant>
@@ -8493,8 +7821,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="74616E6820">
-				<display>tanh&#032;</display>
+			<lang code="en" ti-ascii="74616E6820" display="tanh&#032;">
 				<accessible>tanh&#032;</accessible>
 			</lang>
 		</version>
@@ -8503,8 +7830,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="74616E6828">
-				<display>tanh(</display>
+			<lang code="en" ti-ascii="74616E6828" display="tanh(">
 				<accessible>tanh(</accessible>
 			</lang>
 		</version>
@@ -8519,8 +7845,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</until>
-			<lang code="en" ti-ascii="74616E681120">
-				<display>tanh⁻¹&#032;</display>
+			<lang code="en" ti-ascii="74616E681120" display="tanh⁻¹&#032;">
 				<accessible>tanh^-1&#032;</accessible>
 				<variant>tanh⁻¹&#032;</variant>
 				<variant>arctanh(&#032;</variant>
@@ -8532,8 +7857,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="74616E681128">
-				<display>tanh⁻¹(</display>
+			<lang code="en" ti-ascii="74616E681128" display="tanh⁻¹(">
 				<accessible>tanh^-1(</accessible>
 				<variant>tanh⁻¹(</variant>
 				<variant>arctanh(</variant>
@@ -8547,8 +7871,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="496620">
-				<display>If&#032;</display>
+			<lang code="en" ti-ascii="496620" display="If&#032;">
 				<accessible>If&#032;</accessible>
 			</lang>
 		</version>
@@ -8559,8 +7882,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5468656E">
-				<display>Then</display>
+			<lang code="en" ti-ascii="5468656E" display="Then">
 				<accessible>Then</accessible>
 			</lang>
 		</version>
@@ -8571,8 +7893,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="456C7365">
-				<display>Else</display>
+			<lang code="en" ti-ascii="456C7365" display="Else">
 				<accessible>Else</accessible>
 			</lang>
 		</version>
@@ -8583,8 +7904,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5768696C6520">
-				<display>While&#032;</display>
+			<lang code="en" ti-ascii="5768696C6520" display="While&#032;">
 				<accessible>While&#032;</accessible>
 			</lang>
 		</version>
@@ -8595,8 +7915,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="52657065617420">
-				<display>Repeat&#032;</display>
+			<lang code="en" ti-ascii="52657065617420" display="Repeat&#032;">
 				<accessible>Repeat&#032;</accessible>
 			</lang>
 		</version>
@@ -8607,8 +7926,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="466F7228">
-				<display>For(</display>
+			<lang code="en" ti-ascii="466F7228" display="For(">
 				<accessible>For(</accessible>
 			</lang>
 		</version>
@@ -8619,8 +7937,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="456E64">
-				<display>End</display>
+			<lang code="en" ti-ascii="456E64" display="End">
 				<accessible>End</accessible>
 			</lang>
 		</version>
@@ -8631,8 +7948,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="52657475726E">
-				<display>Return</display>
+			<lang code="en" ti-ascii="52657475726E" display="Return">
 				<accessible>Return</accessible>
 			</lang>
 		</version>
@@ -8643,8 +7959,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4C626C20">
-				<display>Lbl&#032;</display>
+			<lang code="en" ti-ascii="4C626C20" display="Lbl&#032;">
 				<accessible>Lbl&#032;</accessible>
 			</lang>
 		</version>
@@ -8655,8 +7970,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="476F746F20">
-				<display>Goto&#032;</display>
+			<lang code="en" ti-ascii="476F746F20" display="Goto&#032;">
 				<accessible>Goto&#032;</accessible>
 			</lang>
 		</version>
@@ -8667,8 +7981,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="506175736520">
-				<display>Pause&#032;</display>
+			<lang code="en" ti-ascii="506175736520" display="Pause&#032;">
 				<accessible>Pause&#032;</accessible>
 			</lang>
 		</version>
@@ -8679,8 +7992,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="53746F70">
-				<display>Stop</display>
+			<lang code="en" ti-ascii="53746F70" display="Stop">
 				<accessible>Stop</accessible>
 			</lang>
 		</version>
@@ -8691,8 +8003,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="49533E28">
-				<display>IS&gt;(</display>
+			<lang code="en" ti-ascii="49533E28" display="IS&gt;(">
 				<accessible>IS&gt;(</accessible>
 			</lang>
 		</version>
@@ -8703,8 +8014,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="44533C28">
-				<display>DS&lt;(</display>
+			<lang code="en" ti-ascii="44533C28" display="DS&lt;(">
 				<accessible>DS&lt;(</accessible>
 			</lang>
 		</version>
@@ -8715,8 +8025,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="496E70757420">
-				<display>Input&#032;</display>
+			<lang code="en" ti-ascii="496E70757420" display="Input&#032;">
 				<accessible>Input&#032;</accessible>
 			</lang>
 		</version>
@@ -8727,8 +8036,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="50726F6D707420">
-				<display>Prompt&#032;</display>
+			<lang code="en" ti-ascii="50726F6D707420" display="Prompt&#032;">
 				<accessible>Prompt&#032;</accessible>
 			</lang>
 		</version>
@@ -8739,8 +8047,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4469737020">
-				<display>Disp&#032;</display>
+			<lang code="en" ti-ascii="4469737020" display="Disp&#032;">
 				<accessible>Disp&#032;</accessible>
 			</lang>
 		</version>
@@ -8751,8 +8058,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="446973704772617068">
-				<display>DispGraph</display>
+			<lang code="en" ti-ascii="446973704772617068" display="DispGraph">
 				<accessible>DispGraph</accessible>
 			</lang>
 		</version>
@@ -8763,8 +8069,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4F757470757428">
-				<display>Output(</display>
+			<lang code="en" ti-ascii="4F757470757428" display="Output(">
 				<accessible>Output(</accessible>
 			</lang>
 		</version>
@@ -8775,8 +8080,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="436C72486F6D65">
-				<display>ClrHome</display>
+			<lang code="en" ti-ascii="436C72486F6D65" display="ClrHome">
 				<accessible>ClrHome</accessible>
 			</lang>
 		</version>
@@ -8787,8 +8091,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="46696C6C28">
-				<display>Fill(</display>
+			<lang code="en" ti-ascii="46696C6C28" display="Fill(">
 				<accessible>Fill(</accessible>
 			</lang>
 		</version>
@@ -8799,8 +8102,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="536F72744128">
-				<display>SortA(</display>
+			<lang code="en" ti-ascii="536F72744128" display="SortA(">
 				<accessible>SortA(</accessible>
 			</lang>
 		</version>
@@ -8811,8 +8113,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="536F72744428">
-				<display>SortD(</display>
+			<lang code="en" ti-ascii="536F72744428" display="SortD(">
 				<accessible>SortD(</accessible>
 			</lang>
 		</version>
@@ -8823,8 +8124,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="446973705461626C65">
-				<display>DispTable</display>
+			<lang code="en" ti-ascii="446973705461626C65" display="DispTable">
 				<accessible>DispTable</accessible>
 			</lang>
 		</version>
@@ -8835,8 +8135,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4D656E7528">
-				<display>Menu(</display>
+			<lang code="en" ti-ascii="4D656E7528" display="Menu(">
 				<accessible>Menu(</accessible>
 			</lang>
 		</version>
@@ -8847,8 +8146,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="53656E6428">
-				<display>Send(</display>
+			<lang code="en" ti-ascii="53656E6428" display="Send(">
 				<accessible>Send(</accessible>
 			</lang>
 		</version>
@@ -8859,8 +8157,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="47657428">
-				<display>Get(</display>
+			<lang code="en" ti-ascii="47657428" display="Get(">
 				<accessible>Get(</accessible>
 			</lang>
 		</version>
@@ -8871,8 +8168,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="506C6F74734F6E20">
-				<display>PlotsOn&#032;</display>
+			<lang code="en" ti-ascii="506C6F74734F6E20" display="PlotsOn&#032;">
 				<accessible>PlotsOn&#032;</accessible>
 			</lang>
 		</version>
@@ -8883,8 +8179,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="506C6F74734F666620">
-				<display>PlotsOff&#032;</display>
+			<lang code="en" ti-ascii="506C6F74734F666620" display="PlotsOff&#032;">
 				<accessible>PlotsOff&#032;</accessible>
 			</lang>
 		</version>
@@ -8895,8 +8190,7 @@
 				<model>TI-83</model>
 				<os-version>0.01013</os-version>
 			</since>
-			<lang code="en" ti-ascii="DC">
-				<display>ʟ</display>
+			<lang code="en" ti-ascii="DC" display="ʟ">
 				<accessible>smallL</accessible>
 				<variant>ʟ</variant>
 				<variant>⌊</variant>
@@ -8910,8 +8204,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="506C6F743128">
-				<display>Plot1(</display>
+			<lang code="en" ti-ascii="506C6F743128" display="Plot1(">
 				<accessible>Plot1(</accessible>
 			</lang>
 		</version>
@@ -8922,8 +8215,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="506C6F743228">
-				<display>Plot2(</display>
+			<lang code="en" ti-ascii="506C6F743228" display="Plot2(">
 				<accessible>Plot2(</accessible>
 			</lang>
 		</version>
@@ -8934,8 +8226,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="506C6F743328">
-				<display>Plot3(</display>
+			<lang code="en" ti-ascii="506C6F743328" display="Plot3(">
 				<accessible>Plot3(</accessible>
 			</lang>
 		</version>
@@ -8947,8 +8238,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="7365744461746528">
-					<display>setDate(</display>
+				<lang code="en" ti-ascii="7365744461746528" display="setDate(">
 					<accessible>setDate(</accessible>
 				</lang>
 			</version>
@@ -8959,8 +8249,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="73657454696D6528">
-					<display>setTime(</display>
+				<lang code="en" ti-ascii="73657454696D6528" display="setTime(">
 					<accessible>setTime(</accessible>
 				</lang>
 			</version>
@@ -8971,8 +8260,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="636865636B546D7228">
-					<display>checkTmr(</display>
+				<lang code="en" ti-ascii="636865636B546D7228" display="checkTmr(">
 					<accessible>checkTmr(</accessible>
 				</lang>
 			</version>
@@ -8983,8 +8271,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="7365744474466D7428">
-					<display>setDtFmt(</display>
+				<lang code="en" ti-ascii="7365744474466D7428" display="setDtFmt(">
 					<accessible>setDtFmt(</accessible>
 				</lang>
 			</version>
@@ -8995,8 +8282,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="736574546D466D7428">
-					<display>setTmFmt(</display>
+				<lang code="en" ti-ascii="736574546D466D7428" display="setTmFmt(">
 					<accessible>setTmFmt(</accessible>
 				</lang>
 			</version>
@@ -9007,8 +8293,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="74696D65436E7628">
-					<display>timeCnv(</display>
+				<lang code="en" ti-ascii="74696D65436E7628" display="timeCnv(">
 					<accessible>timeCnv(</accessible>
 				</lang>
 			</version>
@@ -9019,8 +8304,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="6461794F66576B28">
-					<display>dayOfWk(</display>
+				<lang code="en" ti-ascii="6461794F66576B28" display="dayOfWk(">
 					<accessible>dayOfWk(</accessible>
 				</lang>
 			</version>
@@ -9031,8 +8315,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="676574447453747228">
-					<display>getDtStr(</display>
+				<lang code="en" ti-ascii="676574447453747228" display="getDtStr(">
 					<accessible>getDtStr(</accessible>
 				</lang>
 			</version>
@@ -9043,8 +8326,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="676574546D53747228">
-					<display>getTmStr(</display>
+				<lang code="en" ti-ascii="676574546D53747228" display="getTmStr(">
 					<accessible>getTmStr(</accessible>
 				</lang>
 			</version>
@@ -9055,8 +8337,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="67657444617465">
-					<display>getDate</display>
+				<lang code="en" ti-ascii="67657444617465" display="getDate">
 					<accessible>getDate</accessible>
 				</lang>
 			</version>
@@ -9067,8 +8348,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="67657454696D65">
-					<display>getTime</display>
+				<lang code="en" ti-ascii="67657454696D65" display="getTime">
 					<accessible>getTime</accessible>
 				</lang>
 			</version>
@@ -9079,8 +8359,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="7374617274546D72">
-					<display>startTmr</display>
+				<lang code="en" ti-ascii="7374617274546D72" display="startTmr">
 					<accessible>startTmr</accessible>
 				</lang>
 			</version>
@@ -9091,8 +8370,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="6765744474466D74">
-					<display>getDtFmt</display>
+				<lang code="en" ti-ascii="6765744474466D74" display="getDtFmt">
 					<accessible>getDtFmt</accessible>
 				</lang>
 			</version>
@@ -9103,8 +8381,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="676574546D466D74">
-					<display>getTmFmt</display>
+				<lang code="en" ti-ascii="676574546D466D74" display="getTmFmt">
 					<accessible>getTmFmt</accessible>
 				</lang>
 			</version>
@@ -9115,8 +8392,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="6973436C6F636B4F6E">
-					<display>isClockOn</display>
+				<lang code="en" ti-ascii="6973436C6F636B4F6E" display="isClockOn">
 					<accessible>isClockOn</accessible>
 				</lang>
 			</version>
@@ -9127,8 +8403,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="436C6F636B4F6666">
-					<display>ClockOff</display>
+				<lang code="en" ti-ascii="436C6F636B4F6666" display="ClockOff">
 					<accessible>ClockOff</accessible>
 				</lang>
 			</version>
@@ -9139,8 +8414,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="436C6F636B4F6E">
-					<display>ClockOn</display>
+				<lang code="en" ti-ascii="436C6F636B4F6E" display="ClockOn">
 					<accessible>ClockOn</accessible>
 				</lang>
 			</version>
@@ -9151,8 +8425,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="4F70656E4C696228">
-					<display>OpenLib(</display>
+				<lang code="en" ti-ascii="4F70656E4C696228" display="OpenLib(">
 					<accessible>OpenLib(</accessible>
 				</lang>
 			</version>
@@ -9163,8 +8436,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="457865634C696220">
-					<display>ExecLib&#032;</display>
+				<lang code="en" ti-ascii="457865634C696220" display="ExecLib&#032;">
 					<accessible>ExecLib&#032;</accessible>
 				</lang>
 			</version>
@@ -9175,8 +8447,7 @@
 					<model>TI-84+</model>
 					<os-version>2.30</os-version>
 				</since>
-				<lang code="en" ti-ascii="696E765428">
-					<display>invT(</display>
+				<lang code="en" ti-ascii="696E765428" display="invT(">
 					<accessible>invT(</accessible>
 				</lang>
 			</version>
@@ -9187,8 +8458,7 @@
 					<model>TI-84+</model>
 					<os-version>2.30</os-version>
 				</since>
-				<lang code="en" ti-ascii="D912474F462D5465737428">
-					<display>χ²GOF-Test(</display>
+				<lang code="en" ti-ascii="D912474F462D5465737428" display="χ²GOF-Test(">
 					<accessible>chi^2GOF-Test(</accessible>
 					<variant>χ²GOF-Test(</variant>
 					<variant>χ^2GOF-Test(</variant>
@@ -9202,8 +8472,7 @@
 					<model>TI-84+</model>
 					<os-version>2.30</os-version>
 				</since>
-				<lang code="en" ti-ascii="4C696E52656754496E7420">
-					<display>LinRegTInt&#032;</display>
+				<lang code="en" ti-ascii="4C696E52656754496E7420" display="LinRegTInt&#032;">
 					<accessible>LinRegTInt&#032;</accessible>
 				</lang>
 			</version>
@@ -9214,8 +8483,7 @@
 					<model>TI-84+</model>
 					<os-version>0.46</os-version>
 				</since>
-				<lang code="en" ti-ascii="4D616E75616C2D46697420">
-					<display>Manual-Fit&#032;</display>
+				<lang code="en" ti-ascii="4D616E75616C2D46697420" display="Manual-Fit&#032;">
 					<accessible>Manual-Fit&#032;</accessible>
 				</lang>
 			</version>
@@ -9226,8 +8494,7 @@
 					<model>TI-84+</model>
 					<os-version>0.01</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A5175616472616E7431">
-					<display>ZQuadrant1</display>
+				<lang code="en" ti-ascii="5A5175616472616E7431" display="ZQuadrant1">
 					<accessible>ZQuadrant1</accessible>
 				</lang>
 			</version>
@@ -9238,8 +8505,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A4672616331F632">
-					<display>ZFrac1⁄2</display>
+				<lang code="en" ti-ascii="5A4672616331F632" display="ZFrac1⁄2">
 					<accessible>ZFrac1/2</accessible>
 					<variant>ZFrac1⁄2</variant>
 				</lang>
@@ -9251,8 +8517,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A4672616331F633">
-					<display>ZFrac1⁄3</display>
+				<lang code="en" ti-ascii="5A4672616331F633" display="ZFrac1⁄3">
 					<accessible>ZFrac1/3</accessible>
 					<variant>ZFrac1⁄3</variant>
 				</lang>
@@ -9264,8 +8529,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A4672616331F634">
-					<display>ZFrac1⁄4</display>
+				<lang code="en" ti-ascii="5A4672616331F634" display="ZFrac1⁄4">
 					<accessible>ZFrac1/4</accessible>
 					<variant>ZFrac1⁄4</variant>
 				</lang>
@@ -9277,8 +8541,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A4672616331F635">
-					<display>ZFrac1⁄5</display>
+				<lang code="en" ti-ascii="5A4672616331F635" display="ZFrac1⁄5">
 					<accessible>ZFrac1/5</accessible>
 					<variant>ZFrac1⁄5</variant>
 				</lang>
@@ -9290,8 +8553,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A4672616331F638">
-					<display>ZFrac1⁄8</display>
+				<lang code="en" ti-ascii="5A4672616331F638" display="ZFrac1⁄8">
 					<accessible>ZFrac1/8</accessible>
 					<variant>ZFrac1⁄8</variant>
 				</lang>
@@ -9303,8 +8565,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="5A4672616331F63130">
-					<display>ZFrac1⁄10</display>
+				<lang code="en" ti-ascii="5A4672616331F63130" display="ZFrac1⁄10">
 					<accessible>ZFrac1/10</accessible>
 					<variant>ZFrac1⁄10</variant>
 				</lang>
@@ -9316,8 +8577,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="F7">
-					<display>.</display>
+				<lang code="en" ti-ascii="F7" display=".">
 					<accessible>mathprintbox</accessible>
 					<variant>⬚</variant>
 				</lang>
@@ -9329,8 +8589,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="F6">
-					<display>⁄</display>
+				<lang code="en" ti-ascii="F6" display="⁄">
 					<accessible>n/d</accessible>
 					<variant>⁄</variant>
 				</lang>
@@ -9342,8 +8601,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="F5">
-					<display>󸏵</display>
+				<lang code="en" ti-ascii="F5" display="󸏵">
 					<accessible>Un/d</accessible>
 					<variant>󸏵</variant>
 					<variant>ᵤ</variant>
@@ -9356,8 +8614,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="056EF664CF05556EF664">
-					<display>►n⁄d◄►Un⁄d</display>
+				<lang code="en" ti-ascii="056EF664CF05556EF664" display="►n⁄d◄►Un⁄d">
 					<accessible>&gt;n/d&lt;&gt;Un/d</accessible>
 					<variant>►n⁄d◄►Un⁄d</variant>
 					<variant>►n/d◄►Un/d</variant>
@@ -9371,8 +8628,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="0546CF0544">
-					<display>►F◄►D</display>
+				<lang code="en" ti-ascii="0546CF0544" display="►F◄►D">
 					<accessible>&gt;F&lt;&gt;D</accessible>
 					<variant>►F◄►D</variant>
 				</lang>
@@ -9384,8 +8640,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="72656D61696E64657228">
-					<display>remainder(</display>
+				<lang code="en" ti-ascii="72656D61696E64657228" display="remainder(">
 					<accessible>remainder(</accessible>
 				</lang>
 			</version>
@@ -9396,8 +8651,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="C628">
-					<display>Σ(</display>
+				<lang code="en" ti-ascii="C628" display="Σ(">
 					<accessible>Sigma(</accessible>
 					<variant>Σ(</variant>
 				</lang>
@@ -9409,8 +8663,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="6C6F674241534528">
-					<display>logBASE(</display>
+				<lang code="en" ti-ascii="6C6F674241534528" display="logBASE(">
 					<accessible>logBASE(</accessible>
 				</lang>
 			</version>
@@ -9421,8 +8674,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="72616E64496E744E6F52657028">
-					<display>randIntNoRep(</display>
+				<lang code="en" ti-ascii="72616E64496E744E6F52657028" display="randIntNoRep(">
 					<accessible>randIntNoRep(</accessible>
 				</lang>
 			</version>
@@ -9433,8 +8685,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="4D4154485052494E54">
-					<display>MATHPRINT</display>
+				<lang code="en" ti-ascii="4D4154485052494E54" display="MATHPRINT">
 					<accessible>[MATHPRINT]</accessible>
 					<variant>MATHPRINT</variant>
 				</lang>
@@ -9446,8 +8697,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="434C4153534943">
-					<display>CLASSIC</display>
+				<lang code="en" ti-ascii="434C4153534943" display="CLASSIC">
 					<accessible>[CLASSIC]</accessible>
 					<variant>CLASSIC</variant>
 				</lang>
@@ -9459,8 +8709,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="6EF664">
-					<display>n⁄d</display>
+				<lang code="en" ti-ascii="6EF664" display="n⁄d">
 					<accessible>[n/d]</accessible>
 					<variant>n⁄d</variant>
 				</lang>
@@ -9472,8 +8721,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="556EF664">
-					<display>Un⁄d</display>
+				<lang code="en" ti-ascii="556EF664" display="Un⁄d">
 					<accessible>[Un/d]</accessible>
 					<variant>Un⁄d</variant>
 				</lang>
@@ -9485,8 +8733,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="4155544F">
-					<display>AUTO</display>
+				<lang code="en" ti-ascii="4155544F" display="AUTO">
 					<accessible>[AUTO]</accessible>
 					<variant>AUTO</variant>
 				</lang>
@@ -9498,8 +8745,7 @@
 					<model>TI-84+</model>
 					<os-version>2.53</os-version>
 				</since>
-				<lang code="en" ti-ascii="444543">
-					<display>DEC</display>
+				<lang code="en" ti-ascii="444543" display="DEC">
 					<accessible>[DEC]</accessible>
 					<variant>DEC</variant>
 				</lang>
@@ -9515,8 +8761,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</until>
-				<lang code="en" ti-ascii="46524143">
-					<display>FRAC</display>
+				<lang code="en" ti-ascii="46524143" display="FRAC">
 					<accessible>[FRAC]</accessible>
 					<variant>FRAC</variant>
 				</lang>
@@ -9526,8 +8771,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="465241432D415050524F58">
-					<display>FRAC-APPROX</display>
+				<lang code="en" ti-ascii="465241432D415050524F58" display="FRAC-APPROX">
 					<accessible>[FRAC-APPROX]</accessible>
 					<variant>FRAC-APPROX</variant>
 				</lang>
@@ -9539,8 +8783,7 @@
 					<model>TI-84+</model>
 					<os-version>2.55</os-version>
 				</since>
-				<lang code="en" ti-ascii="5354415457495A415244204F4E">
-					<display>STATWIZARD ON</display>
+				<lang code="en" ti-ascii="5354415457495A415244204F4E" display="STATWIZARD ON">
 					<accessible>[STATWIZARD ON]</accessible>
 					<variant>STATWIZARD ON</variant>
 				</lang>
@@ -9552,8 +8795,7 @@
 					<model>TI-84+</model>
 					<os-version>2.55</os-version>
 				</since>
-				<lang code="en" ti-ascii="5354415457495A415244204F4646">
-					<display>STATWIZARD OFF</display>
+				<lang code="en" ti-ascii="5354415457495A415244204F4646" display="STATWIZARD OFF">
 					<accessible>[STATWIZARD OFF]</accessible>
 					<variant>STATWIZARD OFF</variant>
 				</lang>
@@ -9565,8 +8807,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="424C5545">
-					<display>BLUE</display>
+				<lang code="en" ti-ascii="424C5545" display="BLUE">
 					<accessible>BLUE</accessible>
 					<variant>Blue</variant>
 				</lang>
@@ -9578,8 +8819,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="524544">
-					<display>RED</display>
+				<lang code="en" ti-ascii="524544" display="RED">
 					<accessible>RED</accessible>
 					<variant>Red</variant>
 				</lang>
@@ -9591,8 +8831,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="424C41434B">
-					<display>BLACK</display>
+				<lang code="en" ti-ascii="424C41434B" display="BLACK">
 					<accessible>BLACK</accessible>
 					<variant>Black</variant>
 				</lang>
@@ -9604,8 +8843,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4D4147454E5441">
-					<display>MAGENTA</display>
+				<lang code="en" ti-ascii="4D4147454E5441" display="MAGENTA">
 					<accessible>MAGENTA</accessible>
 					<variant>Magenta</variant>
 				</lang>
@@ -9617,8 +8855,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="475245454E">
-					<display>GREEN</display>
+				<lang code="en" ti-ascii="475245454E" display="GREEN">
 					<accessible>GREEN</accessible>
 					<variant>Green</variant>
 				</lang>
@@ -9630,8 +8867,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4F52414E4745">
-					<display>ORANGE</display>
+				<lang code="en" ti-ascii="4F52414E4745" display="ORANGE">
 					<accessible>ORANGE</accessible>
 					<variant>Orange</variant>
 				</lang>
@@ -9643,8 +8879,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="42524F574E">
-					<display>BROWN</display>
+				<lang code="en" ti-ascii="42524F574E" display="BROWN">
 					<accessible>BROWN</accessible>
 					<variant>Brown</variant>
 				</lang>
@@ -9656,8 +8891,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4E415659">
-					<display>NAVY</display>
+				<lang code="en" ti-ascii="4E415659" display="NAVY">
 					<accessible>NAVY</accessible>
 					<variant>Navy</variant>
 				</lang>
@@ -9669,8 +8903,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4C54424C5545">
-					<display>LTBLUE</display>
+				<lang code="en" ti-ascii="4C54424C5545" display="LTBLUE">
 					<accessible>LTBLUE</accessible>
 					<variant>LtBlue</variant>
 				</lang>
@@ -9682,8 +8915,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="59454C4C4F57">
-					<display>YELLOW</display>
+				<lang code="en" ti-ascii="59454C4C4F57" display="YELLOW">
 					<accessible>YELLOW</accessible>
 					<variant>Yellow</variant>
 				</lang>
@@ -9695,8 +8927,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5748495445">
-					<display>WHITE</display>
+				<lang code="en" ti-ascii="5748495445" display="WHITE">
 					<accessible>WHITE</accessible>
 					<variant>White</variant>
 				</lang>
@@ -9708,8 +8939,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4C5447524159">
-					<display>LTGRAY</display>
+				<lang code="en" ti-ascii="4C5447524159" display="LTGRAY">
 					<accessible>LTGRAY</accessible>
 					<variant>LtGray</variant>
 					<variant>LTGREY</variant>
@@ -9723,8 +8953,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4D454447524159">
-					<display>MEDGRAY</display>
+				<lang code="en" ti-ascii="4D454447524159" display="MEDGRAY">
 					<accessible>MEDGRAY</accessible>
 					<variant>MedGray</variant>
 					<variant>MEDGREY</variant>
@@ -9738,8 +8967,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="47524159">
-					<display>GRAY</display>
+				<lang code="en" ti-ascii="47524159" display="GRAY">
 					<accessible>GRAY</accessible>
 					<variant>Gray</variant>
 					<variant>GREY</variant>
@@ -9753,8 +8981,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4441524B47524159">
-					<display>DARKGRAY</display>
+				<lang code="en" ti-ascii="4441524B47524159" display="DARKGRAY">
 					<accessible>DARKGRAY</accessible>
 					<variant>DarkGray</variant>
 					<variant>DARKGREY</variant>
@@ -9768,8 +8995,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="496D61676531">
-					<display>Image1</display>
+				<lang code="en" ti-ascii="496D61676531" display="Image1">
 					<accessible>Image1</accessible>
 				</lang>
 			</version>
@@ -9780,8 +9006,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="496D61676532">
-					<display>Image2</display>
+				<lang code="en" ti-ascii="496D61676532" display="Image2">
 					<accessible>Image2</accessible>
 				</lang>
 			</version>
@@ -9792,8 +9017,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="496D61676533">
-					<display>Image3</display>
+				<lang code="en" ti-ascii="496D61676533" display="Image3">
 					<accessible>Image3</accessible>
 				</lang>
 			</version>
@@ -9804,8 +9028,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="496D61676534">
-					<display>Image4</display>
+				<lang code="en" ti-ascii="496D61676534" display="Image4">
 					<accessible>Image4</accessible>
 				</lang>
 			</version>
@@ -9816,8 +9039,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="496D61676535">
-					<display>Image5</display>
+				<lang code="en" ti-ascii="496D61676535" display="Image5">
 					<accessible>Image5</accessible>
 				</lang>
 			</version>
@@ -9828,8 +9050,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="496D61676536">
-					<display>Image6</display>
+				<lang code="en" ti-ascii="496D61676536" display="Image6">
 					<accessible>Image6</accessible>
 				</lang>
 			</version>
@@ -9840,8 +9061,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="496D61676537">
-					<display>Image7</display>
+				<lang code="en" ti-ascii="496D61676537" display="Image7">
 					<accessible>Image7</accessible>
 				</lang>
 			</version>
@@ -9852,8 +9072,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="496D61676538">
-					<display>Image8</display>
+				<lang code="en" ti-ascii="496D61676538" display="Image8">
 					<accessible>Image8</accessible>
 				</lang>
 			</version>
@@ -9864,8 +9083,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="496D61676539">
-					<display>Image9</display>
+				<lang code="en" ti-ascii="496D61676539" display="Image9">
 					<accessible>Image9</accessible>
 				</lang>
 			</version>
@@ -9876,8 +9094,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="496D61676530">
-					<display>Image0</display>
+				<lang code="en" ti-ascii="496D61676530" display="Image0">
 					<accessible>Image0</accessible>
 				</lang>
 			</version>
@@ -9888,8 +9105,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="477269644C696E6520">
-					<display>GridLine&#032;</display>
+				<lang code="en" ti-ascii="477269644C696E6520" display="GridLine&#032;">
 					<accessible>GridLine&#032;</accessible>
 				</lang>
 			</version>
@@ -9900,8 +9116,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4261636B67726F756E644F6E20">
-					<display>BackgroundOn&#032;</display>
+				<lang code="en" ti-ascii="4261636B67726F756E644F6E20" display="BackgroundOn&#032;">
 					<accessible>BackgroundOn&#032;</accessible>
 				</lang>
 			</version>
@@ -9912,8 +9127,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4261636B67726F756E644F6666">
-					<display>BackgroundOff</display>
+				<lang code="en" ti-ascii="4261636B67726F756E644F6666" display="BackgroundOff">
 					<accessible>BackgroundOff</accessible>
 				</lang>
 			</version>
@@ -9924,8 +9138,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4772617068436F6C6F7228">
-					<display>GraphColor(</display>
+				<lang code="en" ti-ascii="4772617068436F6C6F7228" display="GraphColor(">
 					<accessible>GraphColor(</accessible>
 				</lang>
 			</version>
@@ -9936,8 +9149,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="517569636B506C6F74264669742D4551">
-					<display>QuickPlot&amp;Fit-EQ</display>
+				<lang code="en" ti-ascii="517569636B506C6F74264669742D4551" display="QuickPlot&amp;Fit-EQ">
 					<accessible>QuickPlot&amp;Fit-EQ</accessible>
 				</lang>
 			</version>
@@ -9948,8 +9160,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="54657874436F6C6F7228">
-					<display>TextColor(</display>
+				<lang code="en" ti-ascii="54657874436F6C6F7228" display="TextColor(">
 					<accessible>TextColor(</accessible>
 				</lang>
 			</version>
@@ -9960,8 +9171,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="41736D3834435072676D">
-					<display>Asm84CPrgm</display>
+				<lang code="en" ti-ascii="41736D3834435072676D" display="Asm84CPrgm">
 					<accessible>Asm84CPrgm</accessible>
 				</lang>
 			</version>
@@ -9972,8 +9182,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4465746563744173796D4F6E">
-					<display>DetectAsymOn</display>
+				<lang code="en" ti-ascii="4465746563744173796D4F6E" display="DetectAsymOn">
 					<accessible>DetectAsymOn</accessible>
 				</lang>
 			</version>
@@ -9984,8 +9193,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4465746563744173796D4F6666">
-					<display>DetectAsymOff</display>
+				<lang code="en" ti-ascii="4465746563744173796D4F6666" display="DetectAsymOff">
 					<accessible>DetectAsymOff</accessible>
 				</lang>
 			</version>
@@ -9996,8 +9204,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="426F72646572436F6C6F7220">
-					<display>BorderColor&#032;</display>
+				<lang code="en" ti-ascii="426F72646572436F6C6F7220" display="BorderColor&#032;">
 					<accessible>BorderColor&#032;</accessible>
 				</lang>
 			</version>
@@ -10008,8 +9215,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="F9">
-					<display>.</display>
+				<lang code="en" ti-ascii="F9" display=".">
 					<accessible>plottinydot</accessible>
 					<variant>·</variant>
 				</lang>
@@ -10021,8 +9227,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5468696E">
-					<display>Thin</display>
+				<lang code="en" ti-ascii="5468696E" display="Thin">
 					<accessible>Thin</accessible>
 				</lang>
 			</version>
@@ -10033,8 +9238,7 @@
 					<model>TI-84+CSE</model>
 					<os-version>4.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="446F742D5468696E">
-					<display>Dot-Thin</display>
+				<lang code="en" ti-ascii="446F742D5468696E" display="Dot-Thin">
 					<accessible>Dot-Thin</accessible>
 				</lang>
 			</version>
@@ -10045,8 +9249,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.0.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="506C79536D6C7432">
-					<display>PlySmlt2</display>
+				<lang code="en" ti-ascii="506C79536D6C7432" display="PlySmlt2">
 					<accessible>PlySmlt2</accessible>
 				</lang>
 			</version>
@@ -10057,8 +9260,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.0.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="41736D383443455072676D">
-					<display>Asm84CEPrgm</display>
+				<lang code="en" ti-ascii="41736D383443455072676D" display="Asm84CEPrgm">
 					<accessible>Asm84CEPrgm</accessible>
 				</lang>
 			</version>
@@ -10069,8 +9271,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.1.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5175617274696C65732053657474696E67CE">
-					<display>Quartiles Setting…</display>
+				<lang code="en" ti-ascii="5175617274696C65732053657474696E67CE" display="Quartiles Setting…">
 					<accessible>Quartiles Setting...</accessible>
 					<variant>Quartiles Setting…</variant>
 				</lang>
@@ -10082,8 +9283,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7528012D3229">
-					<display>u(𝑛-2)</display>
+				<lang code="en" ti-ascii="7528012D3229" display="u(𝑛-2)">
 					<accessible>u(n-2)</accessible>
 					<variant>u(𝑛-2)</variant>
 					<variant>u(𝒏-2)</variant>
@@ -10096,8 +9296,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7628012D3229">
-					<display>v(𝑛-2)</display>
+				<lang code="en" ti-ascii="7628012D3229" display="v(𝑛-2)">
 					<accessible>v(n-2)</accessible>
 					<variant>v(𝑛-2)</variant>
 					<variant>v(𝒏-2)</variant>
@@ -10110,8 +9309,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7728012D3229">
-					<display>w(𝑛-2)</display>
+				<lang code="en" ti-ascii="7728012D3229" display="w(𝑛-2)">
 					<accessible>w(n-2)</accessible>
 					<variant>w(𝑛-2)</variant>
 					<variant>w(𝒏-2)</variant>
@@ -10124,8 +9322,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7528012D3129">
-					<display>u(𝑛-1)</display>
+				<lang code="en" ti-ascii="7528012D3129" display="u(𝑛-1)">
 					<accessible>u(n-1)</accessible>
 					<variant>u(𝑛-1)</variant>
 					<variant>u(𝒏-1)</variant>
@@ -10138,8 +9335,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7628012D3129">
-					<display>v(𝑛-1)</display>
+				<lang code="en" ti-ascii="7628012D3129" display="v(𝑛-1)">
 					<accessible>v(n-1)</accessible>
 					<variant>v(𝑛-1)</variant>
 					<variant>v(𝒏-1)</variant>
@@ -10152,8 +9348,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7728012D3129">
-					<display>w(𝑛-1)</display>
+				<lang code="en" ti-ascii="7728012D3129" display="w(𝑛-1)">
 					<accessible>w(n-1)</accessible>
 					<variant>w(𝑛-1)</variant>
 					<variant>w(𝒏-1)</variant>
@@ -10166,8 +9361,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="75280129">
-					<display>u(𝑛)</display>
+				<lang code="en" ti-ascii="75280129" display="u(𝑛)">
 					<accessible>u(n)</accessible>
 					<variant>u(𝑛)</variant>
 					<variant>u(𝒏)</variant>
@@ -10180,8 +9374,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="76280129">
-					<display>v(𝑛)</display>
+				<lang code="en" ti-ascii="76280129" display="v(𝑛)">
 					<accessible>v(n)</accessible>
 					<variant>v(𝑛)</variant>
 					<variant>v(𝒏)</variant>
@@ -10194,8 +9387,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="77280129">
-					<display>w(𝑛)</display>
+				<lang code="en" ti-ascii="77280129" display="w(𝑛)">
 					<accessible>w(n)</accessible>
 					<variant>w(𝑛)</variant>
 					<variant>w(𝒏)</variant>
@@ -10208,8 +9400,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7528012B3129">
-					<display>u(𝑛+1)</display>
+				<lang code="en" ti-ascii="7528012B3129" display="u(𝑛+1)">
 					<accessible>u(n+1)</accessible>
 					<variant>u(𝑛+1)</variant>
 					<variant>u(𝒏+1)</variant>
@@ -10222,8 +9413,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7628012B3129">
-					<display>v(𝑛+1)</display>
+				<lang code="en" ti-ascii="7628012B3129" display="v(𝑛+1)">
 					<accessible>v(n+1)</accessible>
 					<variant>v(𝑛+1)</variant>
 					<variant>v(𝒏+1)</variant>
@@ -10236,8 +9426,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="7728012B3129">
-					<display>w(𝑛+1)</display>
+				<lang code="en" ti-ascii="7728012B3129" display="w(𝑛+1)">
 					<accessible>w(n+1)</accessible>
 					<variant>w(𝑛+1)</variant>
 					<variant>w(𝒏+1)</variant>
@@ -10254,8 +9443,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.3.0</os-version>
 				</until>
-				<lang code="en" ti-ascii="70696563655769736528">
-					<display>pieceWise(</display>
+				<lang code="en" ti-ascii="70696563655769736528" display="pieceWise(">
 					<accessible>pieceWise(</accessible>
 				</lang>
 			</version>
@@ -10266,8 +9454,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="534551280129">
-					<display>SEQ(𝑛)</display>
+				<lang code="en" ti-ascii="534551280129" display="SEQ(𝑛)">
 					<accessible>SEQ(n)</accessible>
 					<variant>SEQ(𝑛)</variant>
 					<variant>SEQ(𝒏)</variant>
@@ -10280,8 +9467,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="53455128012B3129">
-					<display>SEQ(𝑛+1)</display>
+				<lang code="en" ti-ascii="53455128012B3129" display="SEQ(𝑛+1)">
 					<accessible>SEQ(n+1)</accessible>
 					<variant>SEQ(𝑛+1)</variant>
 					<variant>SEQ(𝒏+1)</variant>
@@ -10294,8 +9480,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="53455128012B3229">
-					<display>SEQ(𝑛+2)</display>
+				<lang code="en" ti-ascii="53455128012B3229" display="SEQ(𝑛+2)">
 					<accessible>SEQ(n+2)</accessible>
 					<variant>SEQ(𝑛+2)</variant>
 					<variant>SEQ(𝒏+2)</variant>
@@ -10308,8 +9493,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="4C454654">
-					<display>LEFT</display>
+				<lang code="en" ti-ascii="4C454654" display="LEFT">
 					<accessible>LEFT</accessible>
 				</lang>
 			</version>
@@ -10320,8 +9504,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="43454E544552">
-					<display>CENTER</display>
+				<lang code="en" ti-ascii="43454E544552" display="CENTER">
 					<accessible>CENTER</accessible>
 				</lang>
 			</version>
@@ -10332,8 +9515,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5249474854">
-					<display>RIGHT</display>
+				<lang code="en" ti-ascii="5249474854" display="RIGHT">
 					<accessible>RIGHT</accessible>
 				</lang>
 			</version>
@@ -10344,8 +9526,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="696E7642696E6F6D28">
-					<display>invBinom(</display>
+				<lang code="en" ti-ascii="696E7642696E6F6D28" display="invBinom(">
 					<accessible>invBinom(</accessible>
 				</lang>
 			</version>
@@ -10356,8 +9537,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5761697420">
-					<display>Wait&#032;</display>
+				<lang code="en" ti-ascii="5761697420" display="Wait&#032;">
 					<accessible>Wait&#032;</accessible>
 				</lang>
 			</version>
@@ -10368,8 +9548,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="746F537472696E6728">
-					<display>toString(</display>
+				<lang code="en" ti-ascii="746F537472696E6728" display="toString(">
 					<accessible>toString(</accessible>
 				</lang>
 			</version>
@@ -10380,8 +9559,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.2.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="6576616C28">
-					<display>eval(</display>
+				<lang code="en" ti-ascii="6576616C28" display="eval(">
 					<accessible>eval(</accessible>
 				</lang>
 			</version>
@@ -10392,8 +9570,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.3.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="457865637574652050726F6772616D">
-					<display>Execute Program</display>
+				<lang code="en" ti-ascii="457865637574652050726F6772616D" display="Execute Program">
 					<accessible>Execute Program</accessible>
 				</lang>
 			</version>
@@ -10404,8 +9581,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.3.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="556E646F20436C656172">
-					<display>Undo Clear</display>
+				<lang code="en" ti-ascii="556E646F20436C656172" display="Undo Clear">
 					<accessible>Undo Clear</accessible>
 				</lang>
 			</version>
@@ -10416,8 +9592,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.3.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="496E73657274204C696E652041626F7665">
-					<display>Insert Line Above</display>
+				<lang code="en" ti-ascii="496E73657274204C696E652041626F7665" display="Insert Line Above">
 					<accessible>Insert Line Above</accessible>
 				</lang>
 			</version>
@@ -10428,8 +9603,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.3.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="437574204C696E65">
-					<display>Cut Line</display>
+				<lang code="en" ti-ascii="437574204C696E65" display="Cut Line">
 					<accessible>Cut Line</accessible>
 				</lang>
 			</version>
@@ -10440,8 +9614,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.3.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="436F7079204C696E65">
-					<display>Copy Line</display>
+				<lang code="en" ti-ascii="436F7079204C696E65" display="Copy Line">
 					<accessible>Copy Line</accessible>
 				</lang>
 			</version>
@@ -10452,8 +9625,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.3.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5061737465204C696E652042656C6F77">
-					<display>Paste Line Below</display>
+				<lang code="en" ti-ascii="5061737465204C696E652042656C6F77" display="Paste Line Below">
 					<accessible>Paste Line Below</accessible>
 				</lang>
 			</version>
@@ -10464,8 +9636,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.3.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="496E7365727420436F6D6D656E742041626F7665">
-					<display>Insert Comment Above</display>
+				<lang code="en" ti-ascii="496E7365727420436F6D6D656E742041626F7665" display="Insert Comment Above">
 					<accessible>Insert Comment Above</accessible>
 				</lang>
 			</version>
@@ -10476,8 +9647,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.3.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="5175697420456469746F72">
-					<display>Quit Editor</display>
+				<lang code="en" ti-ascii="5175697420456469746F72" display="Quit Editor">
 					<accessible>Quit Editor</accessible>
 				</lang>
 			</version>
@@ -10488,8 +9658,7 @@
 					<model>TI-84+CE</model>
 					<os-version>5.3.0</os-version>
 				</since>
-				<lang code="en" ti-ascii="70696563657769736528">
-					<display>piecewise(</display>
+				<lang code="en" ti-ascii="70696563657769736528" display="piecewise(">
 					<accessible>piecewise(</accessible>
 				</lang>
 			</version>
@@ -10501,8 +9670,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5E">
-				<display>^</display>
+			<lang code="en" ti-ascii="5E" display="^">
 				<accessible>^</accessible>
 			</lang>
 		</version>
@@ -10513,8 +9681,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="CD10">
-				<display>ˣ√</display>
+			<lang code="en" ti-ascii="CD10" display="ˣ√">
 				<accessible>xroot</accessible>
 				<variant>ˣ√</variant>
 			</lang>
@@ -10526,8 +9693,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="312D56617220537461747320">
-				<display>1-Var Stats&#032;</display>
+			<lang code="en" ti-ascii="312D56617220537461747320" display="1-Var Stats&#032;">
 				<accessible>1-Var Stats&#032;</accessible>
 			</lang>
 		</version>
@@ -10538,8 +9704,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="322D56617220537461747320">
-				<display>2-Var Stats&#032;</display>
+			<lang code="en" ti-ascii="322D56617220537461747320" display="2-Var Stats&#032;">
 				<accessible>2-Var Stats&#032;</accessible>
 			</lang>
 		</version>
@@ -10550,8 +9715,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4C696E52656728612B62782920">
-				<display>LinReg(a+bx)&#032;</display>
+			<lang code="en" ti-ascii="4C696E52656728612B62782920" display="LinReg(a+bx)&#032;">
 				<accessible>LinReg(a+bx)&#032;</accessible>
 			</lang>
 		</version>
@@ -10562,8 +9726,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="45787052656720">
-				<display>ExpReg&#032;</display>
+			<lang code="en" ti-ascii="45787052656720" display="ExpReg&#032;">
 				<accessible>ExpReg&#032;</accessible>
 			</lang>
 		</version>
@@ -10574,8 +9737,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4C6E52656720">
-				<display>LnReg&#032;</display>
+			<lang code="en" ti-ascii="4C6E52656720" display="LnReg&#032;">
 				<accessible>LnReg&#032;</accessible>
 			</lang>
 		</version>
@@ -10586,8 +9748,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="50777252656720">
-				<display>PwrReg&#032;</display>
+			<lang code="en" ti-ascii="50777252656720" display="PwrReg&#032;">
 				<accessible>PwrReg&#032;</accessible>
 			</lang>
 		</version>
@@ -10598,8 +9759,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4D65642D4D656420">
-				<display>Med-Med&#032;</display>
+			<lang code="en" ti-ascii="4D65642D4D656420" display="Med-Med&#032;">
 				<accessible>Med-Med&#032;</accessible>
 			</lang>
 		</version>
@@ -10610,8 +9770,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="5175616452656720">
-				<display>QuadReg&#032;</display>
+			<lang code="en" ti-ascii="5175616452656720" display="QuadReg&#032;">
 				<accessible>QuadReg&#032;</accessible>
 			</lang>
 		</version>
@@ -10622,8 +9781,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="436C724C69737420">
-				<display>ClrList&#032;</display>
+			<lang code="en" ti-ascii="436C724C69737420" display="ClrList&#032;">
 				<accessible>ClrList&#032;</accessible>
 			</lang>
 		</version>
@@ -10634,8 +9792,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="436C725461626C65">
-				<display>ClrTable</display>
+			<lang code="en" ti-ascii="436C725461626C65" display="ClrTable">
 				<accessible>ClrTable</accessible>
 			</lang>
 		</version>
@@ -10646,8 +9803,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="486973746F6772616D">
-				<display>Histogram</display>
+			<lang code="en" ti-ascii="486973746F6772616D" display="Histogram">
 				<accessible>Histogram</accessible>
 			</lang>
 		</version>
@@ -10658,8 +9814,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="78794C696E65">
-				<display>xyLine</display>
+			<lang code="en" ti-ascii="78794C696E65" display="xyLine">
 				<accessible>xyLine</accessible>
 			</lang>
 		</version>
@@ -10670,8 +9825,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="53636174746572">
-				<display>Scatter</display>
+			<lang code="en" ti-ascii="53636174746572" display="Scatter">
 				<accessible>Scatter</accessible>
 			</lang>
 		</version>
@@ -10682,8 +9836,7 @@
 				<model>TI-82</model>
 				<os-version>1.0</os-version>
 			</since>
-			<lang code="en" ti-ascii="4C696E5265672861782B622920">
-				<display>LinReg(ax+b)&#032;</display>
+			<lang code="en" ti-ascii="4C696E5265672861782B622920" display="LinReg(ax+b)&#032;">
 				<accessible>LinReg(ax+b)&#032;</accessible>
 			</lang>
 		</version>

--- a/8X.xml
+++ b/8X.xml
@@ -20,6 +20,7 @@
 			<lang code="en" ti-ascii="05444D53">
 				<display>►DMS</display>
 				<accessible>&gt;DMS</accessible>
+				<variant>►DMS</variant>
 			</lang>
 		</version>
 	</token>
@@ -32,6 +33,7 @@
 			<lang code="en" ti-ascii="05446563">
 				<display>►Dec</display>
 				<accessible>&gt;Dec</accessible>
+				<variant>►Dec</variant>
 			</lang>
 		</version>
 	</token>
@@ -44,6 +46,7 @@
 			<lang code="en" ti-ascii="0546726163">
 				<display>►Frac</display>
 				<accessible>&gt;Frac</accessible>
+				<variant>►Frac</variant>
 			</lang>
 		</version>
 	</token>
@@ -56,6 +59,7 @@
 			<lang code="en" ti-ascii="1C">
 				<display>→</display>
 				<accessible>-&gt;</accessible>
+				<variant>→</variant>
 			</lang>
 		</version>
 	</token>
@@ -128,6 +132,7 @@
 			<lang code="en" ti-ascii="15">
 				<display>ʳ</display>
 				<accessible>^^r</accessible>
+				<variant>ʳ</variant>
 			</lang>
 		</version>
 	</token>
@@ -140,6 +145,7 @@
 			<lang code="en" ti-ascii="14">
 				<display>°</display>
 				<accessible>^^o</accessible>
+				<variant>°</variant>
 			</lang>
 		</version>
 	</token>
@@ -152,6 +158,7 @@
 			<lang code="en" ti-ascii="11">
 				<display>⁻¹</display>
 				<accessible>^^-1</accessible>
+				<variant>⁻¹</variant>
 				<variant>ˉ¹</variant>
 			</lang>
 		</version>
@@ -165,6 +172,7 @@
 			<lang code="en" ti-ascii="12">
 				<display>²</display>
 				<accessible>^^2</accessible>
+				<variant>²</variant>
 			</lang>
 		</version>
 	</token>
@@ -177,6 +185,7 @@
 			<lang code="en" ti-ascii="16">
 				<display>ᵀ</display>
 				<accessible>^^T</accessible>
+				<variant>ᵀ</variant>
 			</lang>
 		</version>
 	</token>
@@ -189,6 +198,7 @@
 			<lang code="en" ti-ascii="D5">
 				<display>³</display>
 				<accessible>^^3</accessible>
+				<variant>³</variant>
 			</lang>
 		</version>
 	</token>
@@ -333,6 +343,7 @@
 			<lang code="en" ti-ascii="5205507228">
 				<display>R►Pr(</display>
 				<accessible>R&gt;Pr(</accessible>
+				<variant>R►Pr(</variant>
 			</lang>
 		</version>
 	</token>
@@ -345,6 +356,7 @@
 			<lang code="en" ti-ascii="5205505B28">
 				<display>R►Pθ(</display>
 				<accessible>R&gt;Ptheta(</accessible>
+				<variant>R►Pθ(</variant>
 				<variant>R►Ptheta(</variant>
 				<variant>R&gt;Pθ(</variant>
 			</lang>
@@ -359,6 +371,7 @@
 			<lang code="en" ti-ascii="5005527828">
 				<display>P►Rx(</display>
 				<accessible>P&gt;Rx(</accessible>
+				<variant>P►Rx(</variant>
 			</lang>
 		</version>
 	</token>
@@ -371,6 +384,7 @@
 			<lang code="en" ti-ascii="5005527928">
 				<display>P►Ry(</display>
 				<accessible>P&gt;Ry(</accessible>
+				<variant>P►Ry(</variant>
 			</lang>
 		</version>
 	</token>
@@ -527,6 +541,7 @@
 			<lang code="en" ti-ascii="D7">
 				<display>𝑖</display>
 				<accessible>[i]</accessible>
+				<variant>𝑖</variant>
 			</lang>
 		</version>
 	</token>
@@ -707,6 +722,7 @@
 			<lang code="en" ti-ascii="1B">
 				<display>ᴇ</display>
 				<accessible>|E</accessible>
+				<variant>ᴇ</variant>
 			</lang>
 		</version>
 	</token>
@@ -1091,6 +1107,7 @@
 			<lang code="en" ti-ascii="5B">
 				<display>θ</display>
 				<accessible>theta</accessible>
+				<variant>θ</variant>
 			</lang>
 		</version>
 	</token>
@@ -1226,6 +1243,7 @@
 				<lang code="en" ti-ascii="4C81">
 					<display>L₁</display>
 					<accessible>L1</accessible>
+					<variant>L₁</variant>
 				</lang>
 			</version>
 		</token>
@@ -1238,6 +1256,7 @@
 				<lang code="en" ti-ascii="4C82">
 					<display>L₂</display>
 					<accessible>L2</accessible>
+					<variant>L₂</variant>
 				</lang>
 			</version>
 		</token>
@@ -1250,6 +1269,7 @@
 				<lang code="en" ti-ascii="4C83">
 					<display>L₃</display>
 					<accessible>L3</accessible>
+					<variant>L₃</variant>
 				</lang>
 			</version>
 		</token>
@@ -1262,6 +1282,7 @@
 				<lang code="en" ti-ascii="4C84">
 					<display>L₄</display>
 					<accessible>L4</accessible>
+					<variant>L₄</variant>
 				</lang>
 			</version>
 		</token>
@@ -1274,6 +1295,7 @@
 				<lang code="en" ti-ascii="4C85">
 					<display>L₅</display>
 					<accessible>L5</accessible>
+					<variant>L₅</variant>
 				</lang>
 			</version>
 		</token>
@@ -1286,6 +1308,7 @@
 				<lang code="en" ti-ascii="4C86">
 					<display>L₆</display>
 					<accessible>L6</accessible>
+					<variant>L₆</variant>
 				</lang>
 			</version>
 		</token>
@@ -1300,6 +1323,7 @@
 				<lang code="en" ti-ascii="5981">
 					<display>Y₁</display>
 					<accessible>{Y1}</accessible>
+					<variant>Y₁</variant>
 				</lang>
 			</version>
 		</token>
@@ -1312,6 +1336,7 @@
 				<lang code="en" ti-ascii="5983">
 					<display>Y₂</display>
 					<accessible>{Y2}</accessible>
+					<variant>Y₂</variant>
 				</lang>
 			</version>
 		</token>
@@ -1324,6 +1349,7 @@
 				<lang code="en" ti-ascii="5984">
 					<display>Y₃</display>
 					<accessible>{Y3}</accessible>
+					<variant>Y₃</variant>
 				</lang>
 			</version>
 		</token>
@@ -1336,6 +1362,7 @@
 				<lang code="en" ti-ascii="5985">
 					<display>Y₄</display>
 					<accessible>{Y4}</accessible>
+					<variant>Y₄</variant>
 				</lang>
 			</version>
 		</token>
@@ -1348,6 +1375,7 @@
 				<lang code="en" ti-ascii="5986">
 					<display>Y₅</display>
 					<accessible>{Y5}</accessible>
+					<variant>Y₅</variant>
 				</lang>
 			</version>
 		</token>
@@ -1360,6 +1388,7 @@
 				<lang code="en" ti-ascii="5986">
 					<display>Y₆</display>
 					<accessible>{Y6}</accessible>
+					<variant>Y₆</variant>
 				</lang>
 			</version>
 		</token>
@@ -1372,6 +1401,7 @@
 				<lang code="en" ti-ascii="5987">
 					<display>Y₇</display>
 					<accessible>{Y7}</accessible>
+					<variant>Y₇</variant>
 				</lang>
 			</version>
 		</token>
@@ -1384,6 +1414,7 @@
 				<lang code="en" ti-ascii="5988">
 					<display>Y₈</display>
 					<accessible>{Y8}</accessible>
+					<variant>Y₈</variant>
 				</lang>
 			</version>
 		</token>
@@ -1396,6 +1427,7 @@
 				<lang code="en" ti-ascii="5989">
 					<display>Y₉</display>
 					<accessible>{Y9}</accessible>
+					<variant>Y₉</variant>
 				</lang>
 			</version>
 		</token>
@@ -1408,6 +1440,7 @@
 				<lang code="en" ti-ascii="5980">
 					<display>Y₀</display>
 					<accessible>{Y0}</accessible>
+					<variant>Y₀</variant>
 				</lang>
 			</version>
 		</token>
@@ -1420,6 +1453,7 @@
 				<lang code="en" ti-ascii="58810D">
 					<display>X₁ᴛ</display>
 					<accessible>{X1T}</accessible>
+					<variant>X₁ᴛ</variant>
 				</lang>
 			</version>
 		</token>
@@ -1432,6 +1466,7 @@
 				<lang code="en" ti-ascii="59810D">
 					<display>Y₁ᴛ</display>
 					<accessible>{Y1T}</accessible>
+					<variant>Y₁ᴛ</variant>
 				</lang>
 			</version>
 		</token>
@@ -1444,6 +1479,7 @@
 				<lang code="en" ti-ascii="58820D">
 					<display>X₂ᴛ</display>
 					<accessible>{X2T}</accessible>
+					<variant>X₂ᴛ</variant>
 				</lang>
 			</version>
 		</token>
@@ -1456,6 +1492,7 @@
 				<lang code="en" ti-ascii="59820D">
 					<display>Y₂ᴛ</display>
 					<accessible>{Y2T}</accessible>
+					<variant>Y₂ᴛ</variant>
 				</lang>
 			</version>
 		</token>
@@ -1468,6 +1505,7 @@
 				<lang code="en" ti-ascii="58830D">
 					<display>X₃ᴛ</display>
 					<accessible>{X3T}</accessible>
+					<variant>X₃ᴛ</variant>
 				</lang>
 			</version>
 		</token>
@@ -1480,6 +1518,7 @@
 				<lang code="en" ti-ascii="59830D">
 					<display>Y₃ᴛ</display>
 					<accessible>{Y3T}</accessible>
+					<variant>Y₃ᴛ</variant>
 				</lang>
 			</version>
 		</token>
@@ -1492,6 +1531,7 @@
 				<lang code="en" ti-ascii="58840D">
 					<display>X₄ᴛ</display>
 					<accessible>{X4T}</accessible>
+					<variant>X₄ᴛ</variant>
 				</lang>
 			</version>
 		</token>
@@ -1504,6 +1544,7 @@
 				<lang code="en" ti-ascii="59840D">
 					<display>Y₄ᴛ</display>
 					<accessible>{Y4T}</accessible>
+					<variant>Y₄ᴛ</variant>
 				</lang>
 			</version>
 		</token>
@@ -1516,6 +1557,7 @@
 				<lang code="en" ti-ascii="58850D">
 					<display>X₅ᴛ</display>
 					<accessible>{X5T}</accessible>
+					<variant>X₅ᴛ</variant>
 				</lang>
 			</version>
 		</token>
@@ -1528,6 +1570,7 @@
 				<lang code="en" ti-ascii="59850D">
 					<display>Y₅ᴛ</display>
 					<accessible>{Y5T}</accessible>
+					<variant>Y₅ᴛ</variant>
 				</lang>
 			</version>
 		</token>
@@ -1540,6 +1583,7 @@
 				<lang code="en" ti-ascii="58860D">
 					<display>X₆ᴛ</display>
 					<accessible>{X6T}</accessible>
+					<variant>X₆ᴛ</variant>
 				</lang>
 			</version>
 		</token>
@@ -1552,6 +1596,7 @@
 				<lang code="en" ti-ascii="59860D">
 					<display>Y₆ᴛ</display>
 					<accessible>{Y6T}</accessible>
+					<variant>Y₆ᴛ</variant>
 				</lang>
 			</version>
 		</token>
@@ -1564,6 +1609,7 @@
 				<lang code="en" ti-ascii="7281">
 					<display>r₁</display>
 					<accessible>{r1}</accessible>
+					<variant>r₁</variant>
 				</lang>
 			</version>
 		</token>
@@ -1576,6 +1622,7 @@
 				<lang code="en" ti-ascii="7282">
 					<display>r₂</display>
 					<accessible>{r2}</accessible>
+					<variant>r₂</variant>
 				</lang>
 			</version>
 		</token>
@@ -1588,6 +1635,7 @@
 				<lang code="en" ti-ascii="7283">
 					<display>r₃</display>
 					<accessible>{r3}</accessible>
+					<variant>r₃</variant>
 				</lang>
 			</version>
 		</token>
@@ -1600,6 +1648,7 @@
 				<lang code="en" ti-ascii="7284">
 					<display>r₄</display>
 					<accessible>{r4}</accessible>
+					<variant>r₄</variant>
 				</lang>
 			</version>
 		</token>
@@ -1612,6 +1661,7 @@
 				<lang code="en" ti-ascii="7285">
 					<display>r₅</display>
 					<accessible>{r5}</accessible>
+					<variant>r₅</variant>
 				</lang>
 			</version>
 		</token>
@@ -1624,6 +1674,7 @@
 				<lang code="en" ti-ascii="7286">
 					<display>r₆</display>
 					<accessible>{r6}</accessible>
+					<variant>r₆</variant>
 				</lang>
 			</version>
 		</token>
@@ -1930,6 +1981,7 @@
 				<lang code="en" ti-ascii="5265674551">
 					<display>RegEQ</display>
 					<accessible>[RegEQ]</accessible>
+					<variant>RegEQ</variant>
 				</lang>
 			</version>
 		</token>
@@ -1954,6 +2006,7 @@
 				<lang code="en" ti-ascii="CB">
 					<display>x̄</display>
 					<accessible>[xhat]</accessible>
+					<variant>x̄</variant>
 					<variant>ẋ</variant>
 				</lang>
 			</version>
@@ -1967,6 +2020,7 @@
 				<lang code="en" ti-ascii="C678">
 					<display>Σx</display>
 					<accessible>[Sigmax]</accessible>
+					<variant>Σx</variant>
 				</lang>
 			</version>
 		</token>
@@ -1979,6 +2033,7 @@
 				<lang code="en" ti-ascii="C67812">
 					<display>Σx²</display>
 					<accessible>[Sigmax^2]</accessible>
+					<variant>Σx²</variant>
 					<variant>Σx^2</variant>
 					<variant>sigmax²</variant>
 				</lang>
@@ -1993,6 +2048,7 @@
 				<lang code="en" ti-ascii="5378">
 					<display>Sx</display>
 					<accessible>[Sx]</accessible>
+					<variant>Sx</variant>
 				</lang>
 			</version>
 		</token>
@@ -2005,6 +2061,7 @@
 				<lang code="en" ti-ascii="C778">
 					<display>σx</display>
 					<accessible>[sigmax]</accessible>
+					<variant>σx</variant>
 				</lang>
 			</version>
 		</token>
@@ -2017,6 +2074,7 @@
 				<lang code="en" ti-ascii="6D696E58">
 					<display>minX</display>
 					<accessible>[minX]</accessible>
+					<variant>minX</variant>
 				</lang>
 			</version>
 		</token>
@@ -2029,6 +2087,7 @@
 				<lang code="en" ti-ascii="6D617858">
 					<display>maxX</display>
 					<accessible>[maxX]</accessible>
+					<variant>maxX</variant>
 				</lang>
 			</version>
 		</token>
@@ -2041,6 +2100,7 @@
 				<lang code="en" ti-ascii="6D696E59">
 					<display>minY</display>
 					<accessible>[minY]</accessible>
+					<variant>minY</variant>
 				</lang>
 			</version>
 		</token>
@@ -2053,6 +2113,7 @@
 				<lang code="en" ti-ascii="6D617859">
 					<display>maxY</display>
 					<accessible>[maxY]</accessible>
+					<variant>maxY</variant>
 				</lang>
 			</version>
 		</token>
@@ -2065,6 +2126,7 @@
 				<lang code="en" ti-ascii="CC">
 					<display>ȳ</display>
 					<accessible>[yhat]</accessible>
+					<variant>ȳ</variant>
 				</lang>
 			</version>
 		</token>
@@ -2077,6 +2139,7 @@
 				<lang code="en" ti-ascii="C679">
 					<display>Σy</display>
 					<accessible>[Sigmay]</accessible>
+					<variant>Σy</variant>
 				</lang>
 			</version>
 		</token>
@@ -2089,6 +2152,7 @@
 				<lang code="en" ti-ascii="C67912">
 					<display>Σy²</display>
 					<accessible>[Sigmay^2]</accessible>
+					<variant>Σy²</variant>
 					<variant>Σy^2</variant>
 					<variant>sigmay²</variant>
 				</lang>
@@ -2103,6 +2167,7 @@
 				<lang code="en" ti-ascii="5379">
 					<display>Sy</display>
 					<accessible>[Sy]</accessible>
+					<variant>Sy</variant>
 				</lang>
 			</version>
 		</token>
@@ -2115,6 +2180,7 @@
 				<lang code="en" ti-ascii="C779">
 					<display>σy</display>
 					<accessible>[sigmay]</accessible>
+					<variant>σy</variant>
 				</lang>
 			</version>
 		</token>
@@ -2127,6 +2193,7 @@
 				<lang code="en" ti-ascii="C67879">
 					<display>Σxy</display>
 					<accessible>[Sigmaxy]</accessible>
+					<variant>Σxy</variant>
 				</lang>
 			</version>
 		</token>
@@ -2151,6 +2218,7 @@
 				<lang code="en" ti-ascii="4D6564">
 					<display>Med</display>
 					<accessible>[Med]</accessible>
+					<variant>Med</variant>
 				</lang>
 			</version>
 		</token>
@@ -2163,6 +2231,7 @@
 				<lang code="en" ti-ascii="5181">
 					<display>Q₁</display>
 					<accessible>[Q1]</accessible>
+					<variant>Q₁</variant>
 					<variant>[Q₁]</variant>
 				</lang>
 			</version>
@@ -2176,6 +2245,7 @@
 				<lang code="en" ti-ascii="5183">
 					<display>Q₃</display>
 					<accessible>[Q3]</accessible>
+					<variant>Q₃</variant>
 					<variant>[Q₃]</variant>
 				</lang>
 			</version>
@@ -2249,6 +2319,7 @@
 				<lang code="en" ti-ascii="7881">
 					<display>x₁</display>
 					<accessible>[x1]</accessible>
+					<variant>x₁</variant>
 				</lang>
 			</version>
 		</token>
@@ -2261,6 +2332,7 @@
 				<lang code="en" ti-ascii="7882">
 					<display>x₂</display>
 					<accessible>[x2]</accessible>
+					<variant>x₂</variant>
 				</lang>
 			</version>
 		</token>
@@ -2273,6 +2345,7 @@
 				<lang code="en" ti-ascii="7883">
 					<display>x₃</display>
 					<accessible>[x3]</accessible>
+					<variant>x₃</variant>
 				</lang>
 			</version>
 		</token>
@@ -2285,6 +2358,7 @@
 				<lang code="en" ti-ascii="7981">
 					<display>y₁</display>
 					<accessible>[y1]</accessible>
+					<variant>y₁</variant>
 				</lang>
 			</version>
 		</token>
@@ -2297,6 +2371,7 @@
 				<lang code="en" ti-ascii="7982">
 					<display>y₂</display>
 					<accessible>[y2]</accessible>
+					<variant>y₂</variant>
 				</lang>
 			</version>
 		</token>
@@ -2309,6 +2384,7 @@
 				<lang code="en" ti-ascii="7983">
 					<display>y₃</display>
 					<accessible>[y3]</accessible>
+					<variant>y₃</variant>
 				</lang>
 			</version>
 		</token>
@@ -2321,6 +2397,7 @@
 				<lang code="en" ti-ascii="01">
 					<display>𝑛</display>
 					<accessible>[recursiven]</accessible>
+					<variant>𝑛</variant>
 					<variant>[𝒏]</variant>
 				</lang>
 			</version>
@@ -2370,6 +2447,7 @@
 				<lang code="en" ti-ascii="D912">
 					<display>χ²</display>
 					<accessible>[chi^2]</accessible>
+					<variant>χ²</variant>
 					<variant>χ^2</variant>
 					<variant>chi²</variant>
 				</lang>
@@ -2422,6 +2500,7 @@
 				<lang code="en" ti-ascii="D881">
 					<display>p̂₁</display>
 					<accessible>[phat1]</accessible>
+					<variant>p̂₁</variant>
 					<variant>p̂1</variant>
 					<variant>ṗ₁</variant>
 					<variant>ṗ1</variant>
@@ -2438,6 +2517,7 @@
 				<lang code="en" ti-ascii="D882">
 					<display>p̂₂</display>
 					<accessible>[phat2]</accessible>
+					<variant>p̂₂</variant>
 					<variant>p̂2</variant>
 					<variant>ṗ₂</variant>
 					<variant>ṗ2</variant>
@@ -2454,6 +2534,7 @@
 				<lang code="en" ti-ascii="CB81">
 					<display>x̄₁</display>
 					<accessible>[xhat1]</accessible>
+					<variant>x̄₁</variant>
 					<variant>ẋ₁</variant>
 					<variant>ẋ1</variant>
 					<variant>xhat₁</variant>
@@ -2469,6 +2550,7 @@
 				<lang code="en" ti-ascii="537881">
 					<display>Sx₁</display>
 					<accessible>[Sx1]</accessible>
+					<variant>Sx₁</variant>
 				</lang>
 			</version>
 		</token>
@@ -2481,6 +2563,7 @@
 				<lang code="en" ti-ascii="6E81">
 					<display>n₁</display>
 					<accessible>[n1]</accessible>
+					<variant>n₁</variant>
 				</lang>
 			</version>
 		</token>
@@ -2493,6 +2576,7 @@
 				<lang code="en" ti-ascii="CB82">
 					<display>x̄₂</display>
 					<accessible>[xhat2]</accessible>
+					<variant>x̄₂</variant>
 					<variant>x̄2</variant>
 					<variant>ẋ₂</variant>
 					<variant>ẋ2</variant>
@@ -2509,6 +2593,7 @@
 				<lang code="en" ti-ascii="537882">
 					<display>Sx₂</display>
 					<accessible>[Sx2]</accessible>
+					<variant>Sx₂</variant>
 				</lang>
 			</version>
 		</token>
@@ -2521,6 +2606,7 @@
 				<lang code="en" ti-ascii="6E82">
 					<display>n₂</display>
 					<accessible>[n2]</accessible>
+					<variant>n₂</variant>
 				</lang>
 			</version>
 		</token>
@@ -2533,6 +2619,7 @@
 				<lang code="en" ti-ascii="537870">
 					<display>Sxp</display>
 					<accessible>[Sxp]</accessible>
+					<variant>Sxp</variant>
 				</lang>
 			</version>
 		</token>
@@ -2545,6 +2632,7 @@
 				<lang code="en" ti-ascii="6C6F776572">
 					<display>lower</display>
 					<accessible>[lower]</accessible>
+					<variant>lower</variant>
 				</lang>
 			</version>
 		</token>
@@ -2557,6 +2645,7 @@
 				<lang code="en" ti-ascii="7570706572">
 					<display>upper</display>
 					<accessible>[upper]</accessible>
+					<variant>upper</variant>
 				</lang>
 			</version>
 		</token>
@@ -2581,6 +2670,7 @@
 				<lang code="en" ti-ascii="7212">
 					<display>r²</display>
 					<accessible>[r^2]</accessible>
+					<variant>r²</variant>
 				</lang>
 			</version>
 		</token>
@@ -2593,6 +2683,7 @@
 				<lang code="en" ti-ascii="5212">
 					<display>R²</display>
 					<accessible>[R^2]</accessible>
+					<variant>R²</variant>
 				</lang>
 			</version>
 		</token>
@@ -2741,6 +2832,7 @@
 				<lang code="en" ti-ascii="7528014D696E29">
 					<display>u(𝑛Min)</display>
 					<accessible>u(nMin)</accessible>
+					<variant>u(𝑛Min)</variant>
 					<variant>u(𝒏Min)</variant>
 				</lang>
 			</version>
@@ -2769,6 +2861,7 @@
 				<lang code="en" ti-ascii="7628014D696E29">
 					<display>v(𝑛Min)</display>
 					<accessible>v(nMin)</accessible>
+					<variant>v(𝑛Min)</variant>
 					<variant>v(𝒏Min)</variant>
 				</lang>
 			</version>
@@ -2786,6 +2879,7 @@
 				<lang code="en" ti-ascii="55012D81">
 					<display>U𝑛-₁</display>
 					<accessible>Un-1</accessible>
+					<variant>U𝑛-₁</variant>
 					<variant>U𝒏-₁</variant>
 					<variant>Un-₁</variant>
 				</lang>
@@ -2798,6 +2892,7 @@
 				<lang code="en" ti-ascii="55012D81">
 					<display>U𝑛-₁</display>
 					<accessible>Un-1</accessible>
+					<variant>U𝑛-₁</variant>
 					<variant>U𝒏-₁</variant>
 					<variant>Un-₁</variant>
 				</lang>
@@ -2816,6 +2911,7 @@
 				<lang code="en" ti-ascii="56012D81">
 					<display>V𝑛-₁</display>
 					<accessible>Vn-1</accessible>
+					<variant>V𝑛-₁</variant>
 					<variant>V𝒏-₁</variant>
 					<variant>Vn-₁</variant>
 				</lang>
@@ -2828,6 +2924,7 @@
 				<lang code="en" ti-ascii="56012D81">
 					<display>V𝑛-₁</display>
 					<accessible>Vn-1</accessible>
+					<variant>V𝑛-₁</variant>
 					<variant>V𝒏-₁</variant>
 					<variant>Vn-₁</variant>
 				</lang>
@@ -2842,6 +2939,7 @@
 				<lang code="en" ti-ascii="5A7528014D696E29">
 					<display>Zu(𝑛Min)</display>
 					<accessible>Zu(nMin)</accessible>
+					<variant>Zu(𝑛Min)</variant>
 					<variant>Zu(𝒏Min)</variant>
 					<variant>Zu(nmin)</variant>
 				</lang>
@@ -2856,6 +2954,7 @@
 				<lang code="en" ti-ascii="5A7628014D696E29">
 					<display>Zv(𝑛Min)</display>
 					<accessible>Zv(nMin)</accessible>
+					<variant>Zv(𝑛Min)</variant>
 					<variant>Zv(𝒏Min)</variant>
 					<variant>Zv(nmin)</variant>
 				</lang>
@@ -2942,6 +3041,7 @@
 				<lang code="en" ti-ascii="5B6D696E">
 					<display>θmin</display>
 					<accessible>thetaMin</accessible>
+					<variant>θmin</variant>
 					<variant>θMin</variant>
 				</lang>
 			</version>
@@ -2955,6 +3055,7 @@
 				<lang code="en" ti-ascii="5B6D6178">
 					<display>θmax</display>
 					<accessible>thetaMax</accessible>
+					<variant>θmax</variant>
 					<variant>θMax</variant>
 				</lang>
 			</version>
@@ -3016,6 +3117,7 @@
 				<lang code="en" ti-ascii="5A5B6D696E">
 					<display>Zθmin</display>
 					<accessible>Zthetamin</accessible>
+					<variant>Zθmin</variant>
 				</lang>
 			</version>
 		</token>
@@ -3028,6 +3130,7 @@
 				<lang code="en" ti-ascii="5A5B6D6178">
 					<display>Zθmax</display>
 					<accessible>Zthetamax</accessible>
+					<variant>Zθmax</variant>
 				</lang>
 			</version>
 		</token>
@@ -3080,6 +3183,7 @@
 				<lang code="en" ti-ascii="014D696E">
 					<display>𝑛Min</display>
 					<accessible>nMin</accessible>
+					<variant>𝑛Min</variant>
 					<variant>𝒏Min</variant>
 				</lang>
 			</version>
@@ -3115,6 +3219,7 @@
 				<lang code="en" ti-ascii="014D6178">
 					<display>𝑛Max</display>
 					<accessible>nMax</accessible>
+					<variant>𝑛Max</variant>
 					<variant>𝒏Max</variant>
 				</lang>
 			</version>
@@ -3128,6 +3233,7 @@
 				<lang code="en" ti-ascii="5A014D6178">
 					<display>Z𝑛Max</display>
 					<accessible>ZnMax</accessible>
+					<variant>Z𝑛Max</variant>
 					<variant>Z𝒏Max</variant>
 				</lang>
 			</version>
@@ -3145,6 +3251,7 @@
 				<lang code="en" ti-ascii="015374617274">
 					<display>𝑛Start</display>
 					<accessible>nStart</accessible>
+					<variant>𝑛Start</variant>
 				</lang>
 			</version>
 			<version>
@@ -3155,6 +3262,7 @@
 				<lang code="en" ti-ascii="014D696E">
 					<display>𝑛Min</display>
 					<accessible>nMin</accessible>
+					<variant>𝑛Min</variant>
 					<variant>𝒏Min</variant>
 				</lang>
 			</version>
@@ -3168,6 +3276,7 @@
 				<lang code="en" ti-ascii="5A014D696E">
 					<display>Z𝑛Min</display>
 					<accessible>ZnMin</accessible>
+					<variant>Z𝑛Min</variant>
 					<variant>Z𝒏Min</variant>
 				</lang>
 			</version>
@@ -3181,6 +3290,7 @@
 				<lang code="en" ti-ascii="BE54626C">
 					<display>ΔTbl</display>
 					<accessible>DeltaTbl</accessible>
+					<variant>ΔTbl</variant>
 					<variant>∆Tbl</variant>
 				</lang>
 			</version>
@@ -3206,6 +3316,7 @@
 				<lang code="en" ti-ascii="5B73746570">
 					<display>θstep</display>
 					<accessible>thetastep</accessible>
+					<variant>θstep</variant>
 				</lang>
 			</version>
 		</token>
@@ -3230,6 +3341,7 @@
 				<lang code="en" ti-ascii="5A5B73746570">
 					<display>Zθstep</display>
 					<accessible>Zthetastep</accessible>
+					<variant>Zθstep</variant>
 				</lang>
 			</version>
 		</token>
@@ -3242,6 +3354,7 @@
 				<lang code="en" ti-ascii="BE58">
 					<display>ΔX</display>
 					<accessible>DeltaX</accessible>
+					<variant>ΔX</variant>
 					<variant>∆X</variant>
 				</lang>
 			</version>
@@ -3255,6 +3368,7 @@
 				<lang code="en" ti-ascii="BE59">
 					<display>ΔY</display>
 					<accessible>DeltaY</accessible>
+					<variant>ΔY</variant>
 					<variant>∆Y</variant>
 				</lang>
 			</version>
@@ -3304,6 +3418,7 @@
 				<lang code="en" ti-ascii="DD">
 					<display>𝗡</display>
 					<accessible>|N</accessible>
+					<variant>𝗡</variant>
 					<variant>|𝗡</variant>
 				</lang>
 			</version>
@@ -3365,6 +3480,7 @@
 				<lang code="en" ti-ascii="502F59">
 					<display>P/Y</display>
 					<accessible>|P/Y</accessible>
+					<variant>P/Y</variant>
 				</lang>
 			</version>
 		</token>
@@ -3377,6 +3493,7 @@
 				<lang code="en" ti-ascii="432F59">
 					<display>C/Y</display>
 					<accessible>|C/Y</accessible>
+					<variant>C/Y</variant>
 				</lang>
 			</version>
 		</token>
@@ -3389,6 +3506,7 @@
 				<lang code="en" ti-ascii="7728014D696E29">
 					<display>w(𝑛Min)</display>
 					<accessible>w(nMin)</accessible>
+					<variant>w(𝑛Min)</variant>
 					<variant>w(𝒏Min)</variant>
 				</lang>
 			</version>
@@ -3402,6 +3520,7 @@
 				<lang code="en" ti-ascii="5A7728014D696E29">
 					<display>Zw(𝑛Min)</display>
 					<accessible>Zw(nMin)</accessible>
+					<variant>Zw(𝑛Min)</variant>
 					<variant>Zw(𝒏Min)</variant>
 				</lang>
 			</version>
@@ -3584,6 +3703,7 @@
 			<lang code="en" ti-ascii="17">
 				<display>≤</display>
 				<accessible>&lt;=</accessible>
+				<variant>≤</variant>
 			</lang>
 		</version>
 	</token>
@@ -3596,6 +3716,7 @@
 			<lang code="en" ti-ascii="19">
 				<display>≥</display>
 				<accessible>&gt;=</accessible>
+				<variant>≥</variant>
 			</lang>
 		</version>
 	</token>
@@ -3608,6 +3729,7 @@
 			<lang code="en" ti-ascii="18">
 				<display>≠</display>
 				<accessible>!=</accessible>
+				<variant>≠</variant>
 			</lang>
 		</version>
 	</token>
@@ -4074,6 +4196,7 @@
 			<lang code="en" ti-ascii="0A">
 				<display>□</display>
 				<accessible>squareplot</accessible>
+				<variant>□</variant>
 				<variant>plotsquare</variant>
 			</lang>
 		</version>
@@ -4087,6 +4210,7 @@
 			<lang code="en" ti-ascii="0B">
 				<display>﹢</display>
 				<accessible>crossplot</accessible>
+				<variant>﹢</variant>
 				<variant>plotcross</variant>
 			</lang>
 		</version>
@@ -4751,6 +4875,7 @@
 			<lang code="en" ti-ascii="27">
 				<display>\&apos;</display>
 				<accessible>&apos;</accessible>
+				<variant>\&apos;</variant>
 			</lang>
 		</version>
 	</token>
@@ -4775,6 +4900,7 @@
 			<lang code="en" ti-ascii="1A">
 				<display>⁻</display>
 				<accessible>~</accessible>
+				<variant>⁻</variant>
 				<variant>|-</variant>
 			</lang>
 		</version>
@@ -5057,6 +5183,7 @@
 				<lang code="en" ti-ascii="C650726E28">
 					<display>ΣPrn(</display>
 					<accessible>SigmaPrn(</accessible>
+					<variant>ΣPrn(</variant>
 				</lang>
 			</version>
 		</token>
@@ -5069,6 +5196,7 @@
 				<lang code="en" ti-ascii="C6496E7428">
 					<display>ΣInt(</display>
 					<accessible>SigmaInt(</accessible>
+					<variant>ΣInt(</variant>
 				</lang>
 			</version>
 		</token>
@@ -5081,6 +5209,7 @@
 				<lang code="en" ti-ascii="054E6F6D28">
 					<display>►Nom(</display>
 					<accessible>&gt;Nom(</accessible>
+					<variant>►Nom(</variant>
 				</lang>
 			</version>
 		</token>
@@ -5093,6 +5222,7 @@
 				<lang code="en" ti-ascii="0545666628">
 					<display>►Eff(</display>
 					<accessible>&gt;Eff(</accessible>
+					<variant>►Eff(</variant>
 				</lang>
 			</version>
 		</token>
@@ -5249,6 +5379,7 @@
 				<lang code="en" ti-ascii="D91263646628">
 					<display>χ²cdf(</display>
 					<accessible>chi^2cdf(</accessible>
+					<variant>χ²cdf(</variant>
 					<variant>χ^2cdf(</variant>
 					<variant>chi²cdf(</variant>
 				</lang>
@@ -5263,6 +5394,7 @@
 				<lang code="en" ti-ascii="DA63646628">
 					<display>𝙵cdf(</display>
 					<accessible>Fcdf(</accessible>
+					<variant>𝙵cdf(</variant>
 					<variant>𝐅cdf(</variant>
 				</lang>
 			</version>
@@ -5372,6 +5504,7 @@
 				<lang code="en" ti-ascii="D91270646628">
 					<display>χ²pdf(</display>
 					<accessible>chi^2pdf(</accessible>
+					<variant>χ²pdf(</variant>
 					<variant>χ^2pdf(</variant>
 					<variant>chi²pdf(</variant>
 				</lang>
@@ -5386,6 +5519,7 @@
 				<lang code="en" ti-ascii="DA70646628">
 					<display>𝙵pdf(</display>
 					<accessible>Fpdf(</accessible>
+					<variant>𝙵pdf(</variant>
 					<variant>𝐅pdf(</variant>
 				</lang>
 			</version>
@@ -5447,6 +5581,7 @@
 				<lang code="en" ti-ascii="74766D5FDD">
 					<display>tvm_𝗡</display>
 					<accessible>tvm_N</accessible>
+					<variant>tvm_𝗡</variant>
 				</lang>
 			</version>
 		</token>
@@ -5555,6 +5690,7 @@
 				<lang code="en" ti-ascii="BE4C69737428">
 					<display>ΔList(</display>
 					<accessible>DeltaList(</accessible>
+					<variant>ΔList(</variant>
 				</lang>
 			</version>
 		</token>
@@ -5591,6 +5727,7 @@
 				<lang code="en" ti-ascii="0552656374">
 					<display>►Rect</display>
 					<accessible>&gt;Rect</accessible>
+					<variant>►Rect</variant>
 				</lang>
 			</version>
 		</token>
@@ -5603,6 +5740,7 @@
 				<lang code="en" ti-ascii="05506F6C6172">
 					<display>►Polar</display>
 					<accessible>&gt;Polar</accessible>
+					<variant>►Polar</variant>
 				</lang>
 			</version>
 		</token>
@@ -5615,6 +5753,7 @@
 				<lang code="en" ti-ascii="DB">
 					<display>𝑒</display>
 					<accessible>[e]</accessible>
+					<variant>𝑒</variant>
 				</lang>
 			</version>
 		</token>
@@ -5687,6 +5826,7 @@
 				<lang code="en" ti-ascii="5368616465D91228">
 					<display>Shadeχ²(</display>
 					<accessible>Shadechi^2(</accessible>
+					<variant>Shadeχ²(</variant>
 					<variant>Shadeχ^2(</variant>
 					<variant>Shadechi²(</variant>
 				</lang>
@@ -5701,6 +5841,7 @@
 				<lang code="en" ti-ascii="5368616465DA28BB39">
 					<display>Shade𝙵(</display>
 					<accessible>ShadeF(</accessible>
+					<variant>Shade𝙵(</variant>
 					<variant>Shade𝐅(</variant>
 				</lang>
 			</version>
@@ -5714,6 +5855,7 @@
 				<lang code="en" ti-ascii="4D617472056C69737428">
 					<display>Matr►list(</display>
 					<accessible>Matr&gt;list(</accessible>
+					<variant>Matr►list(</variant>
 				</lang>
 			</version>
 		</token>
@@ -5726,6 +5868,7 @@
 				<lang code="en" ti-ascii="4C697374056D61747228">
 					<display>List►matr(</display>
 					<accessible>List&gt;matr(</accessible>
+					<variant>List►matr(</variant>
 				</lang>
 			</version>
 		</token>
@@ -5798,6 +5941,7 @@
 				<lang code="en" ti-ascii="D9122D5465737428">
 					<display>χ²-Test(</display>
 					<accessible>chi^2-Test(</accessible>
+					<variant>χ²-Test(</variant>
 					<variant>χ^2-Test(</variant>
 					<variant>chi²-Test(</variant>
 				</lang>
@@ -5884,6 +6028,7 @@
 				<lang code="en" ti-ascii="322D53616D70DA5465737420">
 					<display>2-Samp𝙵Test&#032;</display>
 					<accessible>2-SampFTest&#032;</accessible>
+					<variant>2-Samp𝙵Test&#032;</variant>
 					<variant>2-Samp𝐅Test&#032;</variant>
 				</lang>
 			</version>
@@ -5969,6 +6114,7 @@
 				<lang code="en" ti-ascii="72DB5E5BD7">
 					<display>r𝑒^θ𝑖</display>
 					<accessible>re^thetai</accessible>
+					<variant>r𝑒^θ𝑖</variant>
 					<variant>re^θ𝑖</variant>
 					<variant>re^θi</variant>
 					<variant>re^theta𝑖</variant>
@@ -5984,6 +6130,7 @@
 				<lang code="en" ti-ascii="612B62D7">
 					<display>a+b𝑖</display>
 					<accessible>a+bi</accessible>
+					<variant>a+b𝑖</variant>
 				</lang>
 			</version>
 		</token>
@@ -6070,6 +6217,7 @@
 				<lang code="en" ti-ascii="45717505537472696E6728">
 					<display>Equ►String(</display>
 					<accessible>Equ&gt;String(</accessible>
+					<variant>Equ►String(</variant>
 				</lang>
 			</version>
 		</token>
@@ -6082,6 +6230,7 @@
 				<lang code="en" ti-ascii="537472696E670545717528">
 					<display>String►Equ(</display>
 					<accessible>String&gt;Equ(</accessible>
+					<variant>String►Equ(</variant>
 				</lang>
 			</version>
 		</token>
@@ -6778,6 +6927,7 @@
 				<lang code="en" ti-ascii="B6">
 					<display>´</display>
 					<accessible>|&apos;</accessible>
+					<variant>´</variant>
 					<variant>^^&apos;</variant>
 				</lang>
 			</version>
@@ -6804,6 +6954,7 @@
 				<lang code="en" ti-ascii="B8">
 					<display>¨</display>
 					<accessible>|:</accessible>
+					<variant>¨</variant>
 					<variant>^^:</variant>
 				</lang>
 			</version>
@@ -6817,6 +6968,7 @@
 				<lang code="en" ti-ascii="B9">
 					<display>¿</display>
 					<accessible>|?</accessible>
+					<variant>¿</variant>
 				</lang>
 			</version>
 		</token>
@@ -6829,6 +6981,7 @@
 				<lang code="en" ti-ascii="BA">
 					<display>¡</display>
 					<accessible>|!</accessible>
+					<variant>¡</variant>
 				</lang>
 			</version>
 		</token>
@@ -6841,6 +6994,7 @@
 				<lang code="en" ti-ascii="BB">
 					<display>α</display>
 					<accessible>alpha</accessible>
+					<variant>α</variant>
 				</lang>
 			</version>
 		</token>
@@ -6853,6 +7007,7 @@
 				<lang code="en" ti-ascii="BC">
 					<display>β</display>
 					<accessible>beta</accessible>
+					<variant>β</variant>
 				</lang>
 			</version>
 		</token>
@@ -6865,6 +7020,7 @@
 				<lang code="en" ti-ascii="BD">
 					<display>γ</display>
 					<accessible>gamma</accessible>
+					<variant>γ</variant>
 				</lang>
 			</version>
 		</token>
@@ -6877,6 +7033,7 @@
 				<lang code="en" ti-ascii="BE">
 					<display>Δ</display>
 					<accessible>Delta</accessible>
+					<variant>Δ</variant>
 				</lang>
 			</version>
 		</token>
@@ -6889,6 +7046,7 @@
 				<lang code="en" ti-ascii="BF">
 					<display>δ</display>
 					<accessible>delta</accessible>
+					<variant>δ</variant>
 				</lang>
 			</version>
 		</token>
@@ -6901,6 +7059,7 @@
 				<lang code="en" ti-ascii="C0">
 					<display>ε</display>
 					<accessible>epsilon</accessible>
+					<variant>ε</variant>
 				</lang>
 			</version>
 		</token>
@@ -6913,6 +7072,7 @@
 				<lang code="en" ti-ascii="C2">
 					<display>λ</display>
 					<accessible>lambda</accessible>
+					<variant>λ</variant>
 				</lang>
 			</version>
 		</token>
@@ -6925,6 +7085,7 @@
 				<lang code="en" ti-ascii="C3">
 					<display>μ</display>
 					<accessible>mu</accessible>
+					<variant>μ</variant>
 				</lang>
 			</version>
 		</token>
@@ -6950,6 +7111,7 @@
 				<lang code="en" ti-ascii="C5">
 					<display>ρ</display>
 					<accessible>rho</accessible>
+					<variant>ρ</variant>
 				</lang>
 			</version>
 		</token>
@@ -6962,6 +7124,7 @@
 				<lang code="en" ti-ascii="C6">
 					<display>Σ</display>
 					<accessible>Sigma</accessible>
+					<variant>Σ</variant>
 				</lang>
 			</version>
 		</token>
@@ -6974,6 +7137,7 @@
 				<lang code="en" ti-ascii="C9">
 					<display>Φ</display>
 					<accessible>Phi</accessible>
+					<variant>Φ</variant>
 				</lang>
 			</version>
 		</token>
@@ -6986,6 +7150,7 @@
 				<lang code="en" ti-ascii="CA">
 					<display>Ω</display>
 					<accessible>Omega</accessible>
+					<variant>Ω</variant>
 				</lang>
 			</version>
 		</token>
@@ -7011,6 +7176,7 @@
 				<lang code="en" ti-ascii="D9">
 					<display>χ</display>
 					<accessible>chi</accessible>
+					<variant>χ</variant>
 				</lang>
 			</version>
 		</token>
@@ -7349,6 +7515,7 @@
 				<lang code="en" ti-ascii="C7">
 					<display>σ</display>
 					<accessible>sigma</accessible>
+					<variant>σ</variant>
 				</lang>
 			</version>
 		</token>
@@ -7361,6 +7528,7 @@
 				<lang code="en" ti-ascii="C8">
 					<display>τ</display>
 					<accessible>tau</accessible>
+					<variant>τ</variant>
 				</lang>
 			</version>
 		</token>
@@ -7529,6 +7697,7 @@
 				<lang code="en" ti-ascii="CE">
 					<display>…</display>
 					<accessible>...</accessible>
+					<variant>…</variant>
 				</lang>
 			</version>
 		</token>
@@ -7541,6 +7710,7 @@
 				<lang code="en" ti-ascii="13">
 					<display>∠</display>
 					<accessible>|&lt;</accessible>
+					<variant>∠</variant>
 				</lang>
 			</version>
 		</token>
@@ -7553,6 +7723,7 @@
 				<lang code="en" ti-ascii="F4">
 					<display>ß</display>
 					<accessible>sharps</accessible>
+					<variant>ß</variant>
 				</lang>
 			</version>
 		</token>
@@ -7565,6 +7736,7 @@
 				<lang code="en" ti-ascii="CD">
 					<display>ˣ</display>
 					<accessible>^^x</accessible>
+					<variant>ˣ</variant>
 				</lang>
 			</version>
 		</token>
@@ -7577,6 +7749,7 @@
 				<lang code="en" ti-ascii="0D">
 					<display>ᴛ</display>
 					<accessible>smallT</accessible>
+					<variant>ᴛ</variant>
 				</lang>
 			</version>
 		</token>
@@ -7589,6 +7762,7 @@
 				<lang code="en" ti-ascii="80">
 					<display>₀</display>
 					<accessible>small0</accessible>
+					<variant>₀</variant>
 				</lang>
 			</version>
 		</token>
@@ -7601,6 +7775,7 @@
 				<lang code="en" ti-ascii="81">
 					<display>₁</display>
 					<accessible>small1</accessible>
+					<variant>₁</variant>
 				</lang>
 			</version>
 		</token>
@@ -7613,6 +7788,7 @@
 				<lang code="en" ti-ascii="82">
 					<display>₂</display>
 					<accessible>small2</accessible>
+					<variant>₂</variant>
 				</lang>
 			</version>
 		</token>
@@ -7625,6 +7801,7 @@
 				<lang code="en" ti-ascii="83">
 					<display>₃</display>
 					<accessible>small3</accessible>
+					<variant>₃</variant>
 				</lang>
 			</version>
 		</token>
@@ -7637,6 +7814,7 @@
 				<lang code="en" ti-ascii="84">
 					<display>₄</display>
 					<accessible>small4</accessible>
+					<variant>₄</variant>
 				</lang>
 			</version>
 		</token>
@@ -7649,6 +7827,7 @@
 				<lang code="en" ti-ascii="85">
 					<display>₅</display>
 					<accessible>small5</accessible>
+					<variant>₅</variant>
 				</lang>
 			</version>
 		</token>
@@ -7661,6 +7840,7 @@
 				<lang code="en" ti-ascii="86">
 					<display>₆</display>
 					<accessible>small6</accessible>
+					<variant>₆</variant>
 				</lang>
 			</version>
 		</token>
@@ -7673,6 +7853,7 @@
 				<lang code="en" ti-ascii="87">
 					<display>₇</display>
 					<accessible>small7</accessible>
+					<variant>₇</variant>
 				</lang>
 			</version>
 		</token>
@@ -7685,6 +7866,7 @@
 				<lang code="en" ti-ascii="88">
 					<display>₈</display>
 					<accessible>small8</accessible>
+					<variant>₈</variant>
 				</lang>
 			</version>
 		</token>
@@ -7697,6 +7879,7 @@
 				<lang code="en" ti-ascii="89">
 					<display>₉</display>
 					<accessible>small9</accessible>
+					<variant>₉</variant>
 				</lang>
 			</version>
 		</token>
@@ -7709,6 +7892,7 @@
 				<lang code="en" ti-ascii="1D">
 					<display>₁₀</display>
 					<accessible>small10</accessible>
+					<variant>₁₀</variant>
 				</lang>
 			</version>
 		</token>
@@ -7721,6 +7905,7 @@
 				<lang code="en" ti-ascii="CF">
 					<display>◄</display>
 					<accessible>&lt;|</accessible>
+					<variant>◄</variant>
 				</lang>
 			</version>
 		</token>
@@ -7733,6 +7918,7 @@
 				<lang code="en" ti-ascii="05">
 					<display>►</display>
 					<accessible>|&gt;</accessible>
+					<variant>►</variant>
 				</lang>
 			</version>
 		</token>
@@ -7745,6 +7931,7 @@
 				<lang code="en" ti-ascii="1E">
 					<display>↑</display>
 					<accessible>uparrow</accessible>
+					<variant>↑</variant>
 				</lang>
 			</version>
 		</token>
@@ -7757,6 +7944,7 @@
 				<lang code="en" ti-ascii="1F">
 					<display>↓</display>
 					<accessible>downarrow</accessible>
+					<variant>↓</variant>
 				</lang>
 			</version>
 		</token>
@@ -7769,6 +7957,7 @@
 				<lang code="en" ti-ascii="09">
 					<display>×</display>
 					<accessible>xmark</accessible>
+					<variant>×</variant>
 				</lang>
 			</version>
 		</token>
@@ -7781,6 +7970,7 @@
 				<lang code="en" ti-ascii="08">
 					<display>∫</display>
 					<accessible>integral</accessible>
+					<variant>∫</variant>
 				</lang>
 			</version>
 		</token>
@@ -7793,6 +7983,7 @@
 				<lang code="en" ti-ascii="F3">
 					<display>🡁</display>
 					<accessible>bolduparrow</accessible>
+					<variant>🡁</variant>
 					<variant>🡅</variant>
 				</lang>
 			</version>
@@ -7806,6 +7997,7 @@
 				<lang code="en" ti-ascii="07">
 					<display>🠿</display>
 					<accessible>bolddownarrow</accessible>
+					<variant>🠿</variant>
 					<variant>🡇</variant>
 				</lang>
 			</version>
@@ -7831,6 +8023,7 @@
 				<lang code="en" ti-ascii="7F">
 					<display>⌸</display>
 					<accessible>invertedequal</accessible>
+					<variant>⌸</variant>
 				</lang>
 			</version>
 		</token>
@@ -7859,6 +8052,7 @@
 			<lang code="en" ti-ascii="1028">
 				<display>√(</display>
 				<accessible>sqrt(</accessible>
+				<variant>√(</variant>
 			</lang>
 		</version>
 	</token>
@@ -7886,6 +8080,7 @@
 			<lang code="en" ti-ascii="0E1028">
 				<display>³√(</display>
 				<accessible>cuberoot(</accessible>
+				<variant>³√(</variant>
 			</lang>
 		</version>
 	</token>
@@ -7928,6 +8123,7 @@
 			<lang code="en" ti-ascii="DB5E">
 				<display>𝑒^</display>
 				<accessible>e^^</accessible>
+				<variant>𝑒^</variant>
 			</lang>
 		</version>
 		<version>
@@ -7938,6 +8134,7 @@
 			<lang code="en" ti-ascii="DB5E28">
 				<display>𝑒^(</display>
 				<accessible>e^^(</accessible>
+				<variant>𝑒^(</variant>
 			</lang>
 		</version>
 	</token>
@@ -7980,6 +8177,7 @@
 			<lang code="en" ti-ascii="1D5E">
 				<display>₁₀^</display>
 				<accessible>10^^</accessible>
+				<variant>₁₀^</variant>
 			</lang>
 		</version>
 		<version>
@@ -7990,6 +8188,7 @@
 			<lang code="en" ti-ascii="1D5E28">
 				<display>₁₀^(</display>
 				<accessible>10^^(</accessible>
+				<variant>₁₀^(</variant>
 			</lang>
 		</version>
 	</token>
@@ -8698,6 +8897,7 @@
 			<lang code="en" ti-ascii="DC">
 				<display>ʟ</display>
 				<accessible>smallL</accessible>
+				<variant>ʟ</variant>
 				<variant>⌊</variant>
 				<variant>|L</variant>
 			</lang>
@@ -8989,6 +9189,7 @@
 				<lang code="en" ti-ascii="D912474F462D5465737428">
 					<display>χ²GOF-Test(</display>
 					<accessible>chi^2GOF-Test(</accessible>
+					<variant>χ²GOF-Test(</variant>
 					<variant>χ^2GOF-Test(</variant>
 					<variant>chi²GOF-Test(</variant>
 				</lang>
@@ -9039,6 +9240,7 @@
 				<lang code="en" ti-ascii="5A4672616331F632">
 					<display>ZFrac1⁄2</display>
 					<accessible>ZFrac1/2</accessible>
+					<variant>ZFrac1⁄2</variant>
 				</lang>
 			</version>
 		</token>
@@ -9051,6 +9253,7 @@
 				<lang code="en" ti-ascii="5A4672616331F633">
 					<display>ZFrac1⁄3</display>
 					<accessible>ZFrac1/3</accessible>
+					<variant>ZFrac1⁄3</variant>
 				</lang>
 			</version>
 		</token>
@@ -9063,6 +9266,7 @@
 				<lang code="en" ti-ascii="5A4672616331F634">
 					<display>ZFrac1⁄4</display>
 					<accessible>ZFrac1/4</accessible>
+					<variant>ZFrac1⁄4</variant>
 				</lang>
 			</version>
 		</token>
@@ -9075,6 +9279,7 @@
 				<lang code="en" ti-ascii="5A4672616331F635">
 					<display>ZFrac1⁄5</display>
 					<accessible>ZFrac1/5</accessible>
+					<variant>ZFrac1⁄5</variant>
 				</lang>
 			</version>
 		</token>
@@ -9087,6 +9292,7 @@
 				<lang code="en" ti-ascii="5A4672616331F638">
 					<display>ZFrac1⁄8</display>
 					<accessible>ZFrac1/8</accessible>
+					<variant>ZFrac1⁄8</variant>
 				</lang>
 			</version>
 		</token>
@@ -9099,6 +9305,7 @@
 				<lang code="en" ti-ascii="5A4672616331F63130">
 					<display>ZFrac1⁄10</display>
 					<accessible>ZFrac1/10</accessible>
+					<variant>ZFrac1⁄10</variant>
 				</lang>
 			</version>
 		</token>
@@ -9124,6 +9331,7 @@
 				<lang code="en" ti-ascii="F6">
 					<display>⁄</display>
 					<accessible>n/d</accessible>
+					<variant>⁄</variant>
 				</lang>
 			</version>
 		</token>
@@ -9136,6 +9344,7 @@
 				<lang code="en" ti-ascii="F5">
 					<display>󸏵</display>
 					<accessible>Un/d</accessible>
+					<variant>󸏵</variant>
 					<variant>ᵤ</variant>
 				</lang>
 			</version>
@@ -9149,6 +9358,7 @@
 				<lang code="en" ti-ascii="056EF664CF05556EF664">
 					<display>►n⁄d◄►Un⁄d</display>
 					<accessible>&gt;n/d&lt;&gt;Un/d</accessible>
+					<variant>►n⁄d◄►Un⁄d</variant>
 					<variant>►n/d◄►Un/d</variant>
 					<variant>&gt;n⁄d&lt;&gt;Un⁄d</variant>
 				</lang>
@@ -9163,6 +9373,7 @@
 				<lang code="en" ti-ascii="0546CF0544">
 					<display>►F◄►D</display>
 					<accessible>&gt;F&lt;&gt;D</accessible>
+					<variant>►F◄►D</variant>
 				</lang>
 			</version>
 		</token>
@@ -9187,6 +9398,7 @@
 				<lang code="en" ti-ascii="C628">
 					<display>Σ(</display>
 					<accessible>Sigma(</accessible>
+					<variant>Σ(</variant>
 				</lang>
 			</version>
 		</token>
@@ -9223,6 +9435,7 @@
 				<lang code="en" ti-ascii="4D4154485052494E54">
 					<display>MATHPRINT</display>
 					<accessible>[MATHPRINT]</accessible>
+					<variant>MATHPRINT</variant>
 				</lang>
 			</version>
 		</token>
@@ -9235,6 +9448,7 @@
 				<lang code="en" ti-ascii="434C4153534943">
 					<display>CLASSIC</display>
 					<accessible>[CLASSIC]</accessible>
+					<variant>CLASSIC</variant>
 				</lang>
 			</version>
 		</token>
@@ -9247,6 +9461,7 @@
 				<lang code="en" ti-ascii="6EF664">
 					<display>n⁄d</display>
 					<accessible>[n/d]</accessible>
+					<variant>n⁄d</variant>
 				</lang>
 			</version>
 		</token>
@@ -9259,6 +9474,7 @@
 				<lang code="en" ti-ascii="556EF664">
 					<display>Un⁄d</display>
 					<accessible>[Un/d]</accessible>
+					<variant>Un⁄d</variant>
 				</lang>
 			</version>
 		</token>
@@ -9271,6 +9487,7 @@
 				<lang code="en" ti-ascii="4155544F">
 					<display>AUTO</display>
 					<accessible>[AUTO]</accessible>
+					<variant>AUTO</variant>
 				</lang>
 			</version>
 		</token>
@@ -9283,6 +9500,7 @@
 				<lang code="en" ti-ascii="444543">
 					<display>DEC</display>
 					<accessible>[DEC]</accessible>
+					<variant>DEC</variant>
 				</lang>
 			</version>
 		</token>
@@ -9299,6 +9517,7 @@
 				<lang code="en" ti-ascii="46524143">
 					<display>FRAC</display>
 					<accessible>[FRAC]</accessible>
+					<variant>FRAC</variant>
 				</lang>
 			</version>
 			<version>
@@ -9309,6 +9528,7 @@
 				<lang code="en" ti-ascii="465241432D415050524F58">
 					<display>FRAC-APPROX</display>
 					<accessible>[FRAC-APPROX]</accessible>
+					<variant>FRAC-APPROX</variant>
 				</lang>
 			</version>
 		</token>
@@ -9321,6 +9541,7 @@
 				<lang code="en" ti-ascii="5354415457495A415244204F4E">
 					<display>STATWIZARD ON</display>
 					<accessible>[STATWIZARD ON]</accessible>
+					<variant>STATWIZARD ON</variant>
 				</lang>
 			</version>
 		</token>
@@ -9333,6 +9554,7 @@
 				<lang code="en" ti-ascii="5354415457495A415244204F4646">
 					<display>STATWIZARD OFF</display>
 					<accessible>[STATWIZARD OFF]</accessible>
+					<variant>STATWIZARD OFF</variant>
 				</lang>
 			</version>
 		</token>
@@ -9849,6 +10071,7 @@
 				<lang code="en" ti-ascii="5175617274696C65732053657474696E67CE">
 					<display>Quartiles Setting…</display>
 					<accessible>Quartiles Setting...</accessible>
+					<variant>Quartiles Setting…</variant>
 				</lang>
 			</version>
 		</token>
@@ -9861,6 +10084,7 @@
 				<lang code="en" ti-ascii="7528012D3229">
 					<display>u(𝑛-2)</display>
 					<accessible>u(n-2)</accessible>
+					<variant>u(𝑛-2)</variant>
 					<variant>u(𝒏-2)</variant>
 				</lang>
 			</version>
@@ -9874,6 +10098,7 @@
 				<lang code="en" ti-ascii="7628012D3229">
 					<display>v(𝑛-2)</display>
 					<accessible>v(n-2)</accessible>
+					<variant>v(𝑛-2)</variant>
 					<variant>v(𝒏-2)</variant>
 				</lang>
 			</version>
@@ -9887,6 +10112,7 @@
 				<lang code="en" ti-ascii="7728012D3229">
 					<display>w(𝑛-2)</display>
 					<accessible>w(n-2)</accessible>
+					<variant>w(𝑛-2)</variant>
 					<variant>w(𝒏-2)</variant>
 				</lang>
 			</version>
@@ -9900,6 +10126,7 @@
 				<lang code="en" ti-ascii="7528012D3129">
 					<display>u(𝑛-1)</display>
 					<accessible>u(n-1)</accessible>
+					<variant>u(𝑛-1)</variant>
 					<variant>u(𝒏-1)</variant>
 				</lang>
 			</version>
@@ -9913,6 +10140,7 @@
 				<lang code="en" ti-ascii="7628012D3129">
 					<display>v(𝑛-1)</display>
 					<accessible>v(n-1)</accessible>
+					<variant>v(𝑛-1)</variant>
 					<variant>v(𝒏-1)</variant>
 				</lang>
 			</version>
@@ -9926,6 +10154,7 @@
 				<lang code="en" ti-ascii="7728012D3129">
 					<display>w(𝑛-1)</display>
 					<accessible>w(n-1)</accessible>
+					<variant>w(𝑛-1)</variant>
 					<variant>w(𝒏-1)</variant>
 				</lang>
 			</version>
@@ -9939,6 +10168,7 @@
 				<lang code="en" ti-ascii="75280129">
 					<display>u(𝑛)</display>
 					<accessible>u(n)</accessible>
+					<variant>u(𝑛)</variant>
 					<variant>u(𝒏)</variant>
 				</lang>
 			</version>
@@ -9952,6 +10182,7 @@
 				<lang code="en" ti-ascii="76280129">
 					<display>v(𝑛)</display>
 					<accessible>v(n)</accessible>
+					<variant>v(𝑛)</variant>
 					<variant>v(𝒏)</variant>
 				</lang>
 			</version>
@@ -9965,6 +10196,7 @@
 				<lang code="en" ti-ascii="77280129">
 					<display>w(𝑛)</display>
 					<accessible>w(n)</accessible>
+					<variant>w(𝑛)</variant>
 					<variant>w(𝒏)</variant>
 				</lang>
 			</version>
@@ -9978,6 +10210,7 @@
 				<lang code="en" ti-ascii="7528012B3129">
 					<display>u(𝑛+1)</display>
 					<accessible>u(n+1)</accessible>
+					<variant>u(𝑛+1)</variant>
 					<variant>u(𝒏+1)</variant>
 				</lang>
 			</version>
@@ -9991,6 +10224,7 @@
 				<lang code="en" ti-ascii="7628012B3129">
 					<display>v(𝑛+1)</display>
 					<accessible>v(n+1)</accessible>
+					<variant>v(𝑛+1)</variant>
 					<variant>v(𝒏+1)</variant>
 				</lang>
 			</version>
@@ -10004,6 +10238,7 @@
 				<lang code="en" ti-ascii="7728012B3129">
 					<display>w(𝑛+1)</display>
 					<accessible>w(n+1)</accessible>
+					<variant>w(𝑛+1)</variant>
 					<variant>w(𝒏+1)</variant>
 				</lang>
 			</version>
@@ -10033,6 +10268,7 @@
 				<lang code="en" ti-ascii="534551280129">
 					<display>SEQ(𝑛)</display>
 					<accessible>SEQ(n)</accessible>
+					<variant>SEQ(𝑛)</variant>
 					<variant>SEQ(𝒏)</variant>
 				</lang>
 			</version>
@@ -10046,6 +10282,7 @@
 				<lang code="en" ti-ascii="53455128012B3129">
 					<display>SEQ(𝑛+1)</display>
 					<accessible>SEQ(n+1)</accessible>
+					<variant>SEQ(𝑛+1)</variant>
 					<variant>SEQ(𝒏+1)</variant>
 				</lang>
 			</version>
@@ -10059,6 +10296,7 @@
 				<lang code="en" ti-ascii="53455128012B3229">
 					<display>SEQ(𝑛+2)</display>
 					<accessible>SEQ(n+2)</accessible>
+					<variant>SEQ(𝑛+2)</variant>
 					<variant>SEQ(𝒏+2)</variant>
 				</lang>
 			</version>
@@ -10277,6 +10515,7 @@
 			<lang code="en" ti-ascii="CD10">
 				<display>ˣ√</display>
 				<accessible>xroot</accessible>
+				<variant>ˣ√</variant>
 			</lang>
 		</version>
 	</token>

--- a/scripts/parse.py
+++ b/scripts/parse.py
@@ -163,15 +163,13 @@ class Translation:
         code = element.attrib["code"]
 
         ti_ascii = bytes.fromhex(element.attrib["ti-ascii"])
+        display = element.attrib["display"]
 
-        display = ""
         accessible = ""
         variants = []
 
         for child in element:
             match child.tag:
-                case "display":
-                    display = child.text
                 case "accessible":
                     accessible = child.text
                 case "variant":


### PR DESCRIPTION
Adds all `<display>` names as `<variant>` names for the given token so long as
- The name uniquely identifies the token
- The name isn't redundant

Both of those conditions are just the requirements for *any* variant name. Not every display name satisfies them (e.g. stats "e" and lowercase "e"), hence why display names are *not* used by `trie.py` (and hence `tivars_lib_py`) for tokenization. Adding the ones that *are* unique as variants is the most straightforward way to make such names available.

The new sheet passed validation on my end, though it's worth double-checking. 